### PR TITLE
Perform engine autodetection only when `engine=None`

### DIFF
--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -127,7 +127,14 @@ class H5NetCDFStore(WritableCFDataStore):
                     "can't open netCDF4/HDF5 as bytes "
                     "try passing a path or file-like object"
                 )
-        elif not isinstance(filename, str) and filename.tell() != 0:
+            else:
+                if len(filename) > 80:
+                    filename = filename[:80] + b"..."
+                raise ValueError(
+                    "{} is not a valid netCDF file "
+                    "did you mean to pass a string for a path instead?".format(filename)
+                )
+        elif hasattr(filename, 'tell') and filename.tell() != 0:
             raise ValueError(
                 "file-like object read/write pointer not at zero "
                 "please close and reopen, or use a context "

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -333,6 +333,12 @@ class NetCDF4DataStore(WritableCFDataStore):
     ):
         import netCDF4
 
+        if not isinstance(filename, str):
+            raise ValueError(
+                "can only read bytes or file-like objects "
+                "with engine='scipy' or 'h5netcdf'"
+            )
+
         if format is None:
             format = "NETCDF4"
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2224,7 +2224,7 @@ class TestGenericNetCDFData(CFEncodedBase, NetCDF3Only):
                 open_dataset(tmp_file, engine="foobar")
 
         netcdf_bytes = data.to_netcdf()
-        with raises_regex(ValueError, "can only read bytes or file-like"):
+        with raises_regex(ValueError, "unrecognized engine"):
             open_dataset(BytesIO(netcdf_bytes), engine="foobar")
 
     def test_cross_engine_read_write_netcdf3(self):


### PR DESCRIPTION
@aurghs & @TheRed86 the change in functionality in this PR is trivial, but keeping the informative error messages in place is an absolute nightmare!