### PR TITLE
Cfgrib refactor

### DIFF
--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -227,9 +227,7 @@ def open_dataset(
         extra_kwargs["lock"] = lock
     elif engine == "zarr":
         backend_kwargs = backend_kwargs.copy()
-        overwrite_encoded_chunks = backend_kwargs.pop(
-            "overwrite_encoded_chunks", None
-        )
+        overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
         extra_kwargs["mode"] = "r"
         extra_kwargs["group"] = group
 
@@ -245,7 +243,7 @@ def open_dataset(
         use_cftime=use_cftime,
         decode_timedelta=decode_timedelta,
         **backend_kwargs,
-        **extra_kwargs
+        **extra_kwargs,
     )
 
     ds = chunk_backend_ds(backend_ds, chunks, lock=False)

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -12,10 +12,11 @@ from .api import (
     _normalize_path,
     _protect_dataset_variables_inplace,
 )
-from . import h5netcdf_
+from . import h5netcdf_, cfgrib_
 
 ENGINES = {
     "h5netcdf": h5netcdf_.open_backend_dataset_h5necdf,
+    "cfgrib": cfgrib_.open_backend_dataset_cfgrib,
 }
 
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -1,7 +1,9 @@
 import numpy as np
 
+from .. import conventions
 from ..core import indexing
-from ..core.utils import Frozen, FrozenDict
+from ..core.dataset import Dataset
+from ..core.utils import close_on_error, Frozen, FrozenDict
 from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray
 from .locks import SerializableLock, ensure_lock
@@ -69,3 +71,42 @@ class CfGribDataStore(AbstractDataStore):
         dims = self.get_dimensions()
         encoding = {"unlimited_dims": {k for k, v in dims.items() if v is None}}
         return encoding
+
+
+def open_backend_dataset_cfgrib(
+        filename_or_obj,
+        mask_and_scale=None,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        **kwargs
+):
+    store = CfGribDataStore(filename_or_obj, **kwargs)
+
+    with close_on_error(store):
+        vars, attrs = store.load()
+        extra_coords = set()
+        file_obj = store
+        encoding = store.get_encoding()
+
+        vars, attrs, coord_names = conventions.decode_cf_variables(
+            vars,
+            attrs,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+
+        ds = Dataset(vars, attrs=attrs)
+        ds = ds.set_coords(coord_names.union(extra_coords).intersection(vars))
+        ds._file_obj = file_obj
+        ds.encoding = encoding
+
+    return ds

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -74,15 +74,15 @@ class CfGribDataStore(AbstractDataStore):
 
 
 def open_backend_dataset_cfgrib(
-        filename_or_obj,
-        mask_and_scale=None,
-        decode_times=None,
-        concat_characters=None,
-        decode_coords=None,
-        drop_variables=None,
-        use_cftime=None,
-        decode_timedelta=None,
-        **kwargs
+    filename_or_obj,
+    mask_and_scale=None,
+    decode_times=None,
+    concat_characters=None,
+    decode_coords=None,
+    drop_variables=None,
+    use_cftime=None,
+    decode_timedelta=None,
+    **kwargs,
 ):
     store = CfGribDataStore(filename_or_obj, **kwargs)
 


### PR DESCRIPTION
open_backend_dataset_cfgrib() function added in cfgrib_.py file together with necessary imports.
ENGINES entry for cfgrib added in the dictionary. Imports also added for cfgrib_

 - [x] Related to branch **backend_read_refactor**
 - [x] Tests for backends all passed
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [x] New functions/methods added for cfgrib
