### PR TITLE
Reformat dataset_from_backend_dataset.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,7 @@
 blank_issues_enabled: true
 contact_links:
-  - name: General Question
+  - name: Usage question
     url: https://stackoverflow.com/questions/tagged/python-xarray
-    about: "If you have a question like *How do I append to an xarray.Dataset?* then please ask on Stack Overflow using the #python-xarray tag."
+    about: "Post a question on Stack Overflow using the #python-xarray
+    tag. These are regularly reviewed by xarray's maintainers, and questions which
+    include a reproducible example will receive a response."

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -16,6 +16,12 @@ Required dependencies
 Optional dependencies
 ---------------------
 
+.. note::
+
+  If you are using pip to install xarray, optional dependencies can be installed by
+  specifying *extras*. :ref:`installation-instructions` for both pip and conda
+  are given below.
+
 For netCDF and IO
 ~~~~~~~~~~~~~~~~~
 
@@ -116,6 +122,7 @@ You can see the actual minimum tested versions:
 - `For everything else
   <https://github.com/pydata/xarray/blob/master/ci/requirements/py36-min-all-deps.yml>`_
 
+.. _installation-instructions:
 
 Instructions
 ------------
@@ -138,6 +145,26 @@ If you don't use conda, be sure you have the required dependencies (numpy and
 pandas) installed first. Then, install xarray with pip::
 
     $ pip install xarray
+
+We also maintain other dependency sets for different subsets of functionality::
+
+    $ pip install "xarray[io]"        # Install optional dependencies for handling I/O
+    $ pip install "xarray[accel]"     # Install optional dependencies for accelerating xarray
+    $ pip install "xarray[parallel]"  # Install optional dependencies for dask arrays
+    $ pip install "xarray[viz]"       # Install optional dependencies for visualization
+    $ pip install "xarray[complete]"  # Install all the above
+
+The above commands should install most of the `optional dependencies`_. However,
+some packages which are either not listed on PyPI or require extra
+installation steps are excluded. To know which dependencies would be
+installed, take a look at the ``[options.extras_require]`` section in
+``setup.cfg``:
+
+.. literalinclude:: ../setup.cfg
+   :language: ini
+   :start-at: [options.extras_require]
+   :end-before: [options.package_data]
+
 
 Testing
 -------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -36,6 +36,7 @@ New Features
 Bug fixes
 ~~~~~~~~~
 
+- Fix :py:meth:`DataArray.plot.step`. By `Deepak Cherian <https://github.com/dcherian>`_.
 - Fix bug where reading a scalar value from a NetCDF file opened with the ``h5netcdf`` backend would raise a ``ValueError`` when ``decode_cf=True`` (:issue:`4471`, :pull:`4485`).
   By `Gerrit Holl <https://github.com/gerritholl>`_.
 - Fix bug where datetime64 times are silently changed to incorrect values if they are outside the valid date range for ns precision when provided in some other units (:issue:`4427`, :pull:`4454`).
@@ -56,8 +57,19 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+
+- Optional dependencies can be installed along with xarray by specifying
+  extras as ``pip install "xarray[extra]"`` where ``extra`` can be one of ``io``,
+  ``accel``, ``parallel``, ``viz`` and ``complete``. See docs for updated
+  :ref:`installation instructions <installation-instructions>`.
+  (:issue:`2888`, :pull:`4480`).
+  By `Ashwin Vishnu <https://github.com/ashwinvis>`_, `Justus Magin
+  <https://github.com/keewis>`_ and `Mathias Hauser
+  <https://github.com/mathause>`_.
 - Removed stray spaces that stem from black removing new lines (:pull:`4504`).
   By `Mathias Hauser <https://github.com/mathause>`_.
+- Ensure tests are not skipped in the `py38-all-but-dask` test environment
+  (:issue:`4509`). By `Mathias Hauser <https://github.com/mathause>`_.
 
 .. _whats-new.0.16.1:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,52 @@ setup_requires =
     setuptools >= 38.4
     setuptools_scm
 
+[options.extras_require]
+io =
+    netCDF4
+    h5netcdf
+    scipy
+    pydap
+    zarr
+    fsspec
+    cftime
+    rasterio
+    cfgrib
+    ## Scitools packages & dependencies (e.g: cartopy, cf-units) can be hard to install
+    # scitools-iris
+
+accel =
+    scipy
+    bottleneck
+    numbagg
+
+parallel =
+    dask[complete]
+
+viz =
+    matplotlib
+    seaborn
+    nc-time-axis
+    ## Cartopy requires 3rd party libraries and only provides source distributions
+    ## See: https://github.com/SciTools/cartopy/issues/805
+    # cartopy
+
+complete =
+    %(io)s
+    %(accel)s
+    %(parallel)s
+    %(viz)s
+
+docs =
+    %(complete)s
+    sphinx-autosummary-accessors
+    sphinx_rtd_theme
+    ipython
+    ipykernel
+    jupyter-client
+    nbsphinx
+    scanpydoc
+
 [options.package_data]
 xarray =
     py.typed
@@ -111,13 +157,11 @@ exclude=
     doc
 
 [isort]
+profile = black
+skip_gitignore = true
+force_to_top = true
 default_section = THIRDPARTY
 known_first_party = xarray
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-line_length = 88
 
 # Most of the numerical computing stack doesn't have type annotations yet.
 [mypy-affine.*]

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -17,7 +17,13 @@ ENGINES = {
 
 
 def dataset_from_backend_dataset(
-    ds, filename_or_obj, engine, chunks, cache, overwrite_encoded_chunks, extra_tokens,
+        ds,
+        filename_or_obj,
+        engine,
+        chunks,
+        cache,
+        overwrite_encoded_chunks,
+        extra_tokens,
 ):
 
     _protect_dataset_variables_inplace(ds, cache)
@@ -36,9 +42,11 @@ def dataset_from_backend_dataset(
         token = tokenize(filename_or_obj, mtime, engine, chunks, **extra_tokens)
         name_prefix = "open_dataset-%s" % token
         ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
+
     elif engine == "zarr":
         if isinstance(chunks, int):
             chunks = dict.fromkeys(ds.dims, chunks)
+
         variables = {
             k: zarr.ZarrStore.maybe_chunk(k, v, chunks, overwrite_encoded_chunks)
             for k, v in ds.variables.items()

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -19,7 +19,7 @@ ENGINES = {
 def dataset_from_backend_dataset(
     ds, filename_or_obj, engine, chunks, cache, overwrite_encoded_chunks, extra_tokens,
 ):
-    if chunks == 'auto':
+    if chunks == "auto":
         chunks = {}
 
     if not (isinstance(chunks, (int, dict)) or chunks is None):
@@ -47,6 +47,7 @@ def dataset_from_backend_dataset(
     else:
         if engine != "zarr":
             from dask.base import tokenize
+
             token = tokenize(filename_or_obj, mtime, engine, chunks, **extra_tokens)
             name_prefix = "open_dataset-%s" % token
             ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -17,13 +17,13 @@ ENGINES = {
 
 
 def dataset_from_backend_dataset(
-        ds,
-        filename_or_obj,
-        engine,
-        chunks,
-        cache,
-        overwrite_encoded_chunks,
-        extra_tokens,
+    ds,
+    filename_or_obj,
+    engine,
+    chunks,
+    cache,
+    overwrite_encoded_chunks,
+    extra_tokens,
 ):
 
     _protect_dataset_variables_inplace(ds, cache)

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -19,11 +19,6 @@ ENGINES = {
 def dataset_from_backend_dataset(
     ds, filename_or_obj, engine, chunks, cache, overwrite_encoded_chunks, extra_tokens,
 ):
-    if not (isinstance(chunks, (int, dict)) or chunks is None):
-        raise ValueError(
-            "chunks must be an int, dict, 'auto', or None. "
-            "Instead found %s. " % chunks
-        )
 
     _protect_dataset_variables_inplace(ds, cache)
     if chunks is None:
@@ -172,6 +167,12 @@ def open_dataset(
     --------
     open_mfdataset
     """
+
+    if not (isinstance(chunks, (int, dict)) or (chunks is None) or chunks == "auto"):
+        raise ValueError(
+            "chunks must be an int, dict, 'auto', or None. "
+            "Instead found %s. " % chunks
+        )
 
     if cache is None:
         cache = chunks is None

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -19,56 +19,47 @@ ENGINES = {
 def dataset_from_backend_dataset(
     ds, filename_or_obj, engine, chunks, cache, overwrite_encoded_chunks, extra_tokens,
 ):
+    if chunks == 'auto':
+        chunks = {}
+
     if not (isinstance(chunks, (int, dict)) or chunks is None):
-        if chunks != "auto":
-            raise ValueError(
-                "chunks must be an int, dict, 'auto', or None. "
-                "Instead found %s. " % chunks
-            )
+        raise ValueError(
+            "chunks must be an int, dict, 'auto', or None. "
+            "Instead found %s. " % chunks
+        )
 
     _protect_dataset_variables_inplace(ds, cache)
-    if chunks is not None and engine != "zarr":
-        from dask.base import tokenize
-
-        # if passed an actual file path, augment the token with
-        # the file modification time
-        if isinstance(filename_or_obj, str) and not is_remote_uri(filename_or_obj):
-            mtime = os.path.getmtime(filename_or_obj)
-        else:
-            mtime = None
-        token = tokenize(filename_or_obj, mtime, engine, chunks, **extra_tokens)
-        name_prefix = "open_dataset-%s" % token
-        ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
-
-    elif engine == "zarr":
-
-        if chunks == "auto":
-            try:
-                import dask.array  # noqa
-            except ImportError:
-                chunks = None
-
-        if chunks is None:
-            return ds
-
-        if isinstance(chunks, int):
-            chunks = dict.fromkeys(ds.dims, chunks)
-
-        variables = {
-            k: zarr.ZarrStore.maybe_chunk(k, v, chunks, overwrite_encoded_chunks)
-            for k, v in ds.variables.items()
-        }
-        ds2 = ds._replace(variables)
-
-    else:
-        ds2 = ds
-    ds2._file_obj = ds._file_obj
 
     # Ensure source filename always stored in dataset object (GH issue #2550)
     if "source" not in ds.encoding:
         if isinstance(filename_or_obj, str):
             ds.encoding["source"] = filename_or_obj
+            if not is_remote_uri(filename_or_obj):
+                mtime = os.path.getmtime(filename_or_obj)
+            else:
+                mtime = None
 
+    if chunks is None:
+        if engine == "zarr":
+            return ds
+        else:
+            ds2 = ds
+    else:
+        if engine != "zarr":
+            from dask.base import tokenize
+            token = tokenize(filename_or_obj, mtime, engine, chunks, **extra_tokens)
+            name_prefix = "open_dataset-%s" % token
+            ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
+        elif engine == "zarr":
+            if isinstance(chunks, int):
+                chunks = dict.fromkeys(ds.dims, chunks)
+            variables = {
+                k: zarr.ZarrStore.maybe_chunk(k, v, chunks, overwrite_encoded_chunks)
+                for k, v in ds.variables.items()
+            }
+            ds2 = ds._replace(variables)
+
+    ds2._file_obj = ds._file_obj
     return ds2
 
 

--- a/xarray/plot/utils.py
+++ b/xarray/plot/utils.py
@@ -513,16 +513,20 @@ def _resolve_intervals_1dplot(xval, yval, xlabel, ylabel, kwargs):
     # Is it a step plot? (see matplotlib.Axes.step)
     if kwargs.get("drawstyle", "").startswith("steps-"):
 
+        remove_drawstyle = False
         # Convert intervals to double points
         if _valid_other_type(np.array([xval, yval]), [pd.Interval]):
             raise TypeError("Can't step plot intervals against intervals.")
         if _valid_other_type(xval, [pd.Interval]):
             xval, yval = _interval_to_double_bound_points(xval, yval)
+            remove_drawstyle = True
         if _valid_other_type(yval, [pd.Interval]):
             yval, xval = _interval_to_double_bound_points(yval, xval)
+            remove_drawstyle = True
 
         # Remove steps-* to be sure that matplotlib is not confused
-        del kwargs["drawstyle"]
+        if remove_drawstyle:
+            del kwargs["drawstyle"]
 
     # Is it another kind of plot?
     else:

--- a/xarray/tests/test_accessor_dt.py
+++ b/xarray/tests/test_accessor_dt.py
@@ -6,13 +6,14 @@ import xarray as xr
 
 from . import (
     assert_array_equal,
+    assert_chunks_equal,
     assert_equal,
     assert_identical,
+    raise_if_dask_computes,
     raises_regex,
     requires_cftime,
     requires_dask,
 )
-from .test_dask import assert_chunks_equal, raise_if_dask_computes
 
 
 class TestDatetimeAccessor:

--- a/xarray/tests/test_coding_times.py
+++ b/xarray/tests/test_coding_times.py
@@ -391,15 +391,15 @@ def test_decode_multidim_time_outside_timestamp_range(calendar):
 
 
 @requires_cftime
-@pytest.mark.parametrize("calendar", ["360_day", "all_leap", "366_day"])
-def test_decode_non_standard_calendar_single_element(calendar):
+@pytest.mark.parametrize(
+    ("calendar", "num_time"),
+    [("360_day", 720058.0), ("all_leap", 732059.0), ("366_day", 732059.0)],
+)
+def test_decode_non_standard_calendar_single_element(calendar, num_time):
     import cftime
 
     units = "days since 0001-01-01"
 
-    dt = cftime.datetime(2001, 2, 29)
-
-    num_time = cftime.date2num(dt, units, calendar)
     actual = coding.times.decode_cf_datetime(num_time, units, calendar=calendar)
 
     expected = np.asarray(

--- a/xarray/tests/test_dask.py
+++ b/xarray/tests/test_dask.py
@@ -23,6 +23,7 @@ from . import (
     assert_equal,
     assert_frame_equal,
     assert_identical,
+    raise_if_dask_computes,
     raises_regex,
     requires_pint_0_15,
     requires_scipy_or_netCDF4,
@@ -34,30 +35,6 @@ da = pytest.importorskip("dask.array")
 dd = pytest.importorskip("dask.dataframe")
 
 ON_WINDOWS = sys.platform == "win32"
-
-
-class CountingScheduler:
-    """Simple dask scheduler counting the number of computes.
-
-    Reference: https://stackoverflow.com/questions/53289286/"""
-
-    def __init__(self, max_computes=0):
-        self.total_computes = 0
-        self.max_computes = max_computes
-
-    def __call__(self, dsk, keys, **kwargs):
-        self.total_computes += 1
-        if self.total_computes > self.max_computes:
-            raise RuntimeError(
-                "Too many computes. Total: %d > max: %d."
-                % (self.total_computes, self.max_computes)
-            )
-        return dask.get(dsk, keys, **kwargs)
-
-
-def raise_if_dask_computes(max_computes=0):
-    scheduler = CountingScheduler(max_computes)
-    return dask.config.set(scheduler=scheduler)
 
 
 def test_raise_if_dask_computes():

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -32,6 +32,7 @@ from xarray.tests import (
     assert_equal,
     assert_identical,
     has_dask,
+    raise_if_dask_computes,
     raises_regex,
     requires_bottleneck,
     requires_dask,
@@ -41,8 +42,6 @@ from xarray.tests import (
     requires_sparse,
     source_ndarray,
 )
-
-from .test_dask import raise_if_dask_computes
 
 
 class TestDataArray:

--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -670,11 +670,13 @@ class TestPlotStep(PlotTestCase):
         self.darray = DataArray(easy_array((2, 3, 4)))
 
     def test_step(self):
-        self.darray[0, 0].plot.step()
+        hdl = self.darray[0, 0].plot.step()
+        assert "steps" in hdl[0].get_drawstyle()
 
-    @pytest.mark.parametrize("ds", ["pre", "post", "mid"])
-    def test_step_with_drawstyle(self, ds):
-        self.darray[0, 0].plot.step(drawstyle=ds)
+    @pytest.mark.parametrize("where", ["pre", "post", "mid"])
+    def test_step_with_where(self, where):
+        hdl = self.darray[0, 0].plot.step(where=where)
+        assert hdl[0].get_drawstyle() == f"steps-{where}"
 
     def test_coord_with_interval_step(self):
         """Test step plot with intervals."""


### PR DESCRIPTION
Improve readability of dataset_from_backend_dataset to unify chunks' definition for all backends. 

 - [ ] Part of issue #4496, 
 - [ ] Passes all available tests,
 - [ ] Passes `isort . && black . && mypy . && flake8`.