### PR TITLE
Introduce explicit ModuleNotFoundError if open_mfdaset used without d…

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -944,8 +944,12 @@ def open_mfdataset(
         open_ = open_dataset
         getattr_ = getattr
 
-    datasets = [open_(p, **open_kwargs) for p in paths]
-    file_objs = [getattr_(ds, "_file_obj") for ds in datasets]
+    try:
+        datasets = [open_(p, **open_kwargs) for p in paths]
+        file_objs = [getattr_(ds, "_file_obj") for ds in datasets]
+    except ImportError:
+        raise ModuleNotFoundError("Function open_mfdataset() requires dask to be installed")
+
     if preprocess is not None:
         datasets = [preprocess(ds) for ds in datasets]
 

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -949,7 +949,6 @@ def open_mfdataset(
 
     datasets = [open_(p, **open_kwargs) for p in paths]
     file_objs = [getattr_(ds, "_file_obj") for ds in datasets]
-
     if preprocess is not None:
         datasets = [preprocess(ds) for ds in datasets]
 


### PR DESCRIPTION
ModuleNotFoundError implemented if open_mfdataset function is used to open file(s) without dask installed.

 - [ ] Closes #2634
 - [ ] All tests passed
 - [ ] Passes `isort . && black . && mypy . && flake8`
