### PR TITLE
Change signature open dataset

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -434,9 +434,10 @@ def open_dataset(
     """
     if os.environ.get("XARRAY_BACKEND_API", "v1") == "v2":
         kwargs = locals().copy()
+        from . import plugins
         from . import apiv2
 
-        if engine in apiv2.ENGINES:
+        if engine in plugins.ENGINES:
             return apiv2.open_dataset(**kwargs)
 
     if autoclose is not None:

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -434,8 +434,7 @@ def open_dataset(
     """
     if os.environ.get("XARRAY_BACKEND_API", "v1") == "v2":
         kwargs = locals().copy()
-        from . import plugins
-        from . import apiv2
+        from . import apiv2, plugins
 
         if engine in plugins.ENGINES:
             return apiv2.open_dataset(**kwargs)

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -134,8 +134,9 @@ def open_dataset(
         change the behavior of coordinates corresponding to dimensions, which
         always load their data from disk into a ``pandas.Index``.
     decode_cf : bool, optional
-        Whether to decode these variables, assuming they were saved according
-        to CF conventions.
+        Setting ``decode_cf=False`` will disable ``mask_and_scale``,
+        ``decode_times``, ``decode_timedelta``, ``concat_characters``,
+        ``decode_coords``
     mask_and_scale : bool, optional
         If True, replace array values equal to `_FillValue` with NA and scale
         values according to the formula `original_values * scale_factor +
@@ -175,19 +176,23 @@ def open_dataset(
         A variable or list of variables to exclude from being parsed from the
         dataset. This may be useful to drop variables with problems or
         inconsistent values.
-    backend_kwargs: dict, optional
-        A dictionary of keyword arguments to pass on to the backend. This
-        may be useful when backend options would improve performance or
-        allow user control of dataset processing.
-    kwargs: dict, optional
-        A dictionary of keyword arguments to pass on to the backend, such as
-        **group** (path to the netCDF4 group in the given file to open given as a str),
-        **lock** (resource lock to use when reading data from disk. Only relevant when
-        using dask or another form of parallelism. By default, appropriate
-        locks are chosen to safely read and write files with the currently
-        active dask scheduler),
-        **chunks** (int or dict, if chunks is provided, it is used to load the new dataset into dask
-        arrays).
+    backend_kwargs:
+        Additional keyword arguments passed on to the engine open function.
+    **kwargs: dict
+        Additional keyword arguments passed on to the engine open function.
+        For example:
+
+        - 'group': path to the netCDF4 group in the given file to open given as
+        a str,supported by "netcdf4", "h5netcdf", "zarr".
+
+        - 'lock': resource lock to use when reading data from disk. Only
+        relevant when using dask or another form of parallelism. By default,
+        appropriate locks are chosen to safely read and write files with the
+        currently active dask scheduler. Supported by "netcdf4", "h5netcdf",
+        "pynio", "pseudonetcdf", "cfgrib".
+
+        See engine open function for kwargs accepted by each specific engine.
+
 
     Returns
     -------

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -25,11 +25,8 @@ def dataset_from_backend_dataset(
     overwrite_encoded_chunks,
     extra_tokens,
 ):
-    if chunks == 'auto':
-        chunks = {}
-
     if not (isinstance(chunks, (int, dict)) or chunks is None):
-        if chunks != {}:
+        if chunks != "auto":
             raise ValueError(
                 "chunks must be an int, dict, 'auto', or None. "
                 "Instead found %s. " % chunks
@@ -51,7 +48,7 @@ def dataset_from_backend_dataset(
 
     elif engine == "zarr":
 
-        if chunks == {}:
+        if chunks == "auto":
             try:
                 import dask.array  # noqa
             except ImportError:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -2,7 +2,8 @@ import inspect
 import os
 
 from ..core.utils import is_remote_uri
-from . import cfgrib_, h5netcdf_, zarr
+from . import zarr
+from . import plugins
 from .api import (
     _autodetect_engine,
     _get_backend_cls,
@@ -10,11 +11,6 @@ from .api import (
     _protect_dataset_variables_inplace,
 )
 
-ENGINES = {
-    "h5netcdf": h5netcdf_.open_backend_dataset_h5necdf,
-    "zarr": zarr.open_backend_dataset_zarr,
-    "cfgrib": cfgrib_.open_backend_dataset_cfgrib,
-}
 
 
 def dataset_from_backend_dataset(
@@ -80,7 +76,7 @@ def dataset_from_backend_dataset(
 
 
 def resolve_decoders_kwargs(decode_cf, engine, **decoders):
-    signature = inspect.signature(ENGINES[engine]).parameters
+    signature = plugins.ENGINES[engine]["signature"]
     if decode_cf is False:
         for d in decoders:
             if d in signature and d != "use_cftime":
@@ -240,7 +236,7 @@ def open_dataset(
     backend_kwargs = backend_kwargs.copy()
     overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
 
-    open_backend_dataset = _get_backend_cls(engine, engines=ENGINES)
+    open_backend_dataset = _get_backend_cls(engine, engines=plugins.ENGINES)['open_dataset']
     backend_ds = open_backend_dataset(
         filename_or_obj,
         drop_variables=drop_variables,

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -1,16 +1,13 @@
-import inspect
 import os
 
 from ..core.utils import is_remote_uri
-from . import zarr
-from . import plugins
+from . import plugins, zarr
 from .api import (
     _autodetect_engine,
     _get_backend_cls,
     _normalize_path,
     _protect_dataset_variables_inplace,
 )
-
 
 
 def dataset_from_backend_dataset(
@@ -236,7 +233,9 @@ def open_dataset(
     backend_kwargs = backend_kwargs.copy()
     overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
 
-    open_backend_dataset = _get_backend_cls(engine, engines=plugins.ENGINES)['open_dataset']
+    open_backend_dataset = _get_backend_cls(engine, engines=plugins.ENGINES)[
+        "open_dataset"
+    ]
     backend_ds = open_backend_dataset(
         filename_or_obj,
         drop_variables=drop_variables,

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -112,14 +112,14 @@ def open_dataset(
     filename_or_obj : str, Path, file-like or DataStore
         Strings and Path objects are interpreted as a path to a netCDF file
         or an OpenDAP URL and opened with python-netCDF4, unless the filename
-        ends with .gz, in which case the file is gunzipped and opened with
+        ends with .gz, in which case the file is unzipped and opened with
         scipy.io.netcdf (only netCDF3 supported). Byte-strings or file-like
         objects are opened by scipy.io.netcdf (netCDF3) or h5py (netCDF4/HDF).
-    engine : {"netcdf4", "scipy", "pydap", "h5netcdf", "pynio", "cfgrib", \
-        "pseudonetcdf", "zarr"}, optional
+    engine : str, optional
         Engine to use when reading files. If not provided, the default engine
         is chosen based on available dependencies, with a preference for
-        "netcdf4".
+        "netcdf4". Options are: {"netcdf4", "scipy", "pydap", "h5netcdf",\
+        "pynio", "cfgrib", "pseudonetcdf", "zarr"}.
     chunks : int or dict, optional
         If chunks is provided, it is used to load the new dataset into dask
         arrays. ``chunks={}`` loads the dataset with dask using a single
@@ -127,7 +127,7 @@ def open_dataset(
         ``chunks='auto'`` will create dask chunks based on the variable's zarr
         chunks.
     cache : bool, optional
-        If True, cache data loaded from the underlying datastore in memory as
+        If True, cache data is loaded from the underlying datastore in memory as
         NumPy arrays when accessed to avoid reading from the underlying data-
         store multiple times. Defaults to True unless you specify the `chunks`
         argument to use dask, in which case it defaults to False. Does not
@@ -136,24 +136,26 @@ def open_dataset(
     decode_cf : bool, optional
         Setting ``decode_cf=False`` will disable ``mask_and_scale``,
         ``decode_times``, ``decode_timedelta``, ``concat_characters``,
-        ``decode_coords``
+        ``decode_coords``.
     mask_and_scale : bool, optional
-        If True, replace array values equal to `_FillValue` with NA and scale
-        values according to the formula `original_values * scale_factor +
+        If True, array values equal to `_FillValue` are replaced with NA and other
+        values are scaled according to the formula `original_values * scale_factor +
         add_offset`, where `_FillValue`, `scale_factor` and `add_offset` are
         taken from variable attributes (if they exist).  If the `_FillValue` or
-        `missing_value` attribute contains multiple values a warning will be
+        `missing_value` attribute contains multiple values, a warning will be
         issued and all array values matching one of the multiple values will
         be replaced by NA. mask_and_scale defaults to True except for the
-        pseudonetcdf backend.
+        pseudonetcdf backend. This keyword may not be supported by all the backends.
     decode_times : bool, optional
         If True, decode times encoded in the standard NetCDF datetime format
         into datetime objects. Otherwise, leave them encoded as numbers.
+        This keyword may not be supported by all the backends.
     decode_timedelta : bool, optional
         If True, decode variables and coordinates with time units in
         {"days", "hours", "minutes", "seconds", "milliseconds", "microseconds"}
-        into timedelta objects. If False, leave them encoded as numbers.
+        into timedelta objects. If False, they remain encoded as numbers.
         If None (default), assume the same value of decode_time.
+        This keyword may not be supported by all the backends.
     use_cftime: bool, optional
         Only relevant if encoded dates come from a standard calendar
         (e.g. "gregorian", "proleptic_gregorian", "standard", or not
@@ -163,18 +165,20 @@ def open_dataset(
         ``cftime.datetime`` objects, regardless of whether or not they can be
         represented using ``np.datetime64[ns]`` objects.  If False, always
         decode times to ``np.datetime64[ns]`` objects; if this is not possible
-        raise an error.
+        raise an error. This keyword may not be supported by all the backends.
     concat_characters : bool, optional
         If True, concatenate along the last dimension of character arrays to
         form string arrays. Dimensions will only be concatenated over (and
         removed) if they have no corresponding variable and if they are only
         used as the last dimension of character arrays.
+        This keyword may not be supported by all the backends.
     decode_coords : bool, optional
         If True, decode the 'coordinates' attribute to identify coordinates in
-        the resulting dataset.
+        the resulting dataset. This keyword may not be supported by all the
+        backends.
     drop_variables: str or iterable, optional
-        A variable or list of variables to exclude from being parsed from the
-        dataset. This may be useful to drop variables with problems or
+        A variable or list of variables to exclude from the dataset parsing.
+        This may be useful to drop variables with problems or
         inconsistent values.
     backend_kwargs:
         Additional keyword arguments passed on to the engine open function.

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -25,8 +25,12 @@ def dataset_from_backend_dataset(
     overwrite_encoded_chunks,
     extra_tokens,
 ):
+    if chunks == 'auto':
+        chunks = {}
+
     if not (isinstance(chunks, (int, dict)) or chunks is None):
-        if chunks != "auto":
+
+        if chunks != {}:
             raise ValueError(
                 "chunks must be an int, dict, 'auto', or None. "
                 "Instead found %s. " % chunks
@@ -47,8 +51,7 @@ def dataset_from_backend_dataset(
         ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
 
     elif engine == "zarr":
-
-        if chunks == "auto":
+        if chunks == {}:
             try:
                 import dask.array  # noqa
             except ImportError:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -29,7 +29,6 @@ def dataset_from_backend_dataset(
         chunks = {}
 
     if not (isinstance(chunks, (int, dict)) or chunks is None):
-
         if chunks != {}:
             raise ValueError(
                 "chunks must be an int, dict, 'auto', or None. "
@@ -51,6 +50,7 @@ def dataset_from_backend_dataset(
         ds2 = ds.chunk(chunks, name_prefix=name_prefix, token=token)
 
     elif engine == "zarr":
+
         if chunks == {}:
             try:
                 import dask.array  # noqa

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -74,7 +74,7 @@ def dataset_from_backend_dataset(
     # Ensure source filename always stored in dataset object (GH issue #2550)
     if "source" not in ds.encoding:
         if isinstance(filename_or_obj, str):
-            ds.encoding["source"] = filename_or_obj
+            ds2.encoding["source"] = filename_or_obj
 
     return ds2
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -76,8 +76,8 @@ def resolve_decoders_kwargs(decode_cf, engine, **decoders):
     signature = plugins.ENGINES[engine]["signature"]
     if decode_cf is False:
         for d in decoders:
-            if d in signature and d != "use_cftime":
-                decoders[d] = decode_cf
+            if d in signature:
+                decoders[d] = False
     return {k: v for k, v in decoders.items() if v is not None}
 
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -94,7 +94,7 @@ def open_dataset(
     engine=None,
     chunks=None,
     cache=None,
-    decode_cf=True,
+    decode_cf=None,
     mask_and_scale=None,
     decode_times=None,
     decode_timedelta=None,

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -76,7 +76,6 @@ class CfGribDataStore(AbstractDataStore):
 def open_backend_dataset_cfgrib(
     filename_or_obj,
     *,
-    decode_cf=True,
     mask_and_scale=True,
     decode_times=None,
     concat_characters=None,
@@ -92,13 +91,6 @@ def open_backend_dataset_cfgrib(
     squeeze=True,
     time_dims=("time", "step"),
 ):
-
-    if not decode_cf:
-        mask_and_scale = False
-        decode_times = False
-        concat_characters = False
-        decode_coords = False
-        decode_timedelta = False
 
     store = CfGribDataStore(
         filename_or_obj,

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -328,7 +328,6 @@ class H5NetCDFStore(WritableCFDataStore):
 def open_backend_dataset_h5necdf(
     filename_or_obj,
     *,
-    decode_cf=True,
     mask_and_scale=True,
     decode_times=None,
     concat_characters=None,
@@ -342,13 +341,6 @@ def open_backend_dataset_h5necdf(
     invalid_netcdf=None,
     phony_dims=None,
 ):
-
-    if not decode_cf:
-        mask_and_scale = False
-        decode_times = False
-        concat_characters = False
-        decode_coords = False
-        decode_timedelta = False
 
     store = H5NetCDFStore.open(
         filename_or_obj,

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -2,7 +2,6 @@ import inspect
 
 from . import cfgrib_, h5netcdf_, zarr
 
-
 ENGINES = {
     "h5netcdf": {
         "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,
@@ -20,9 +19,12 @@ for engine in ENGINES.values():
     if "signature" not in engine:
         parameters = inspect.signature(engine["open_dataset"]).parameters
         for name, param in parameters.items():
-            if param.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+            if param.kind in (
+                inspect.Parameter.VAR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            ):
                 raise TypeError(
-                    f'All the parameters in {engine["open_dataset"]!r} signature should be explicit. ' 
-                    '*args and **kwargs is not supported'
+                    f'All the parameters in {engine["open_dataset"]!r} signature should be explicit. '
+                    "*args and **kwargs is not supported"
                 )
         engine["signature"] = set(parameters)

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -3,7 +3,8 @@ import typing as T
 
 from . import cfgrib_, h5netcdf_, zarr
 
-ENGINES: T.Dict[str, T.Dict] = {
+
+ENGINES: T.Dict[str, T.Dict[str, T.Any]] = {
     "h5netcdf": {
         "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,
     },

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -3,7 +3,6 @@ import typing as T
 
 from . import cfgrib_, h5netcdf_, zarr
 
-
 ENGINES: T.Dict[str, T.Dict[str, T.Any]] = {
     "h5netcdf": {
         "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,8 +1,9 @@
 import inspect
+import typing as T
 
 from . import cfgrib_, h5netcdf_, zarr
 
-ENGINES = {
+ENGINES: T.Dict[str, T.Dict] = {
     "h5netcdf": {
         "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,
     },

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,0 +1,28 @@
+import inspect
+
+from . import cfgrib_, h5netcdf_, zarr
+
+
+ENGINES = {
+    "h5netcdf": {
+        "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,
+    },
+    "zarr": {
+        "open_dataset": zarr.open_backend_dataset_zarr,
+    },
+    "cfgrib": {
+        "open_dataset": cfgrib_.open_backend_dataset_cfgrib,
+    },
+}
+
+
+for engine in ENGINES.values():
+    if "signature" not in engine:
+        parameters = inspect.signature(engine["open_dataset"]).parameters
+        for name, param in parameters.items():
+            if param.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+                raise TypeError(
+                    f'All the parameters in {engine["open_dataset"]!r} signature should be explicit. ' 
+                    '*args and **kwargs is not supported'
+                )
+        engine["signature"] = set(parameters)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -684,7 +684,6 @@ def open_zarr(
 
 def open_backend_dataset_zarr(
     filename_or_obj,
-    decode_cf=True,
     mask_and_scale=True,
     decode_times=None,
     concat_characters=None,
@@ -699,13 +698,6 @@ def open_backend_dataset_zarr(
     consolidate_on_close=False,
     chunk_store=None,
 ):
-
-    if not decode_cf:
-        mask_and_scale = False
-        decode_times = False
-        concat_characters = False
-        decode_coords = False
-        decode_timedelta = False
 
     store = ZarrStore.open_group(
         filename_or_obj,


### PR DESCRIPTION
That is a proposal/draft for the new API of `open_dataset()`. It is implemented in `apiv2.py` and it doesn't modify the current behavior of`api.open_dataset()`. 
- Implements the first of the alternative suggested at https://github.com/pydata/xarray/issues/4490#issue-715374721, see the related quoted text:
 > **Describe alternatives you've considered**
> 
> For the overall approach:
> 
> 1. We could keep the current design, with separate keyword arguments for decoding options, and just be very careful about passing around these arguments. This seems pretty painful for the backend refactor, though.
> 2. We could keep the current design only for the user facing `open_dataset()` interface, and then internally convert into the `DecodingOptions()` struct for passing to backend constructors. This would provide much needed flexibility for backend authors, but most users wouldn't benefit from the new interface. Perhaps this would make sense as an intermediate step?

- Align documentation.


 - [x] reletaed to  https://github.com/pydata/xarray/issues/4490#
 - [x] Passes `isort . && black . && mypy . && flake8`
