### PR TITLE
Backends entrypoints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,12 @@ setup_requires =
     setuptools >= 38.4
     setuptools_scm
 
+[options.entry_points]
+xarray.backends =
+    zarr = xarray.backends.zarr:open_backend_dataset_zarr
+    h5netcdf = xarray.backends.h5netcdf_:open_backend_dataset_h5necdf
+    cfgrib = xarray.backends.cfgrib_:open_backend_dataset_cfgrib
+
 [options.extras_require]
 io =
     netCDF4

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -435,8 +435,17 @@ def open_dataset(
     if os.environ.get("XARRAY_BACKEND_API", "v1") == "v2":
         kwargs = locals().copy()
         from . import apiv2
+        import sys
+        import entrypoints
 
-        if engine in apiv2.ENGINES:
+        path = sys.path.copy()
+        path = set(path)
+
+        try:
+            entrypoints.get_single("xarray.backends", engine, path=path)
+        except Exception:
+            "continue"
+        else:
             return apiv2.open_dataset(**kwargs)
 
     if autoclose is not None:


### PR DESCRIPTION
Entry points have been introduced in setup.cfg for the available backends and used in apiv2.py to select the corresponding engine.

 - [ ] Part of #3166
 - [ ] Tests all passed
 - [ ] Passes `isort . && black .  && flake8`
