### PR TITLE
Backends entrypoints

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - dask
   - distributed
   - dask_labextension
+  - entrypoints
   - h5netcdf
   - h5py
   - hdf5

--- a/ci/requirements/py36-bare-minimum.yml
+++ b/ci/requirements/py36-bare-minimum.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.6
   - coveralls
+  - entrypoints
   - pip
   - pytest
   - pytest-cov

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -17,6 +17,7 @@ dependencies:
   - coveralls
   - dask=2.9
   - distributed=2.9
+  - entrypoints
   - flake8
   - h5netcdf=0.7
   - h5py=2.9  # Policy allows for 2.10, but it's a conflict-fest

--- a/ci/requirements/py36-min-nep18.yml
+++ b/ci/requirements/py36-min-nep18.yml
@@ -8,6 +8,7 @@ dependencies:
   - coveralls
   - dask=2.9
   - distributed=2.9
+  - entrypoints
   - numpy=1.17
   - pandas=0.25
   - pint=0.15

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -13,6 +13,7 @@ dependencies:
   - coveralls
   - dask
   - distributed
+  - entrypoints
   - flake8
   - h5netcdf
   - h5py

--- a/ci/requirements/py37-windows.yml
+++ b/ci/requirements/py37-windows.yml
@@ -13,6 +13,7 @@ dependencies:
   - coveralls
   - dask
   - distributed
+  - entrypoints
   - flake8
   - h5netcdf
   - h5py

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -13,6 +13,7 @@ dependencies:
   - coveralls
   - dask
   - distributed
+  - entrypoints
   - flake8
   - h5netcdf
   - h5py

--- a/ci/requirements/py38-all-but-dask.yml
+++ b/ci/requirements/py38-all-but-dask.yml
@@ -11,6 +11,7 @@ dependencies:
   - cfgrib
   - cftime
   - coveralls
+  - entrypoints
   - flake8
   - h5netcdf
   - h5py

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -13,6 +13,7 @@ dependencies:
   - coveralls
   - dask
   - distributed
+  - entrypoints
   - flake8
   - h5netcdf
   - h5py

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ install_requires =
     numpy >= 1.15
     pandas >= 0.25
     setuptools >= 38.4  # For pkg_resources
+    entrypoints >= 0.3
 setup_requires =
     setuptools >= 38.4
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,12 @@ setup_requires =
     setuptools >= 38.4
     setuptools_scm
 
+[options.entry_points]
+xarray.backends =
+    zarr = xarray.backends.zarr:open_backend_dataset_zarr
+    h5netcdf = xarray.backends.h5netcdf_:open_backend_dataset_h5necdf
+    cfgrib = xarray.backends.cfgrib_:open_backend_dataset_cfgrib
+
 [options.extras_require]
 io =
     netCDF4

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,9 +84,9 @@ setup_requires =
 
 [options.entry_points]
 xarray.backends =
-    zarr = xarray.backends.zarr:open_backend_dataset_zarr
-    h5netcdf = xarray.backends.h5netcdf_:open_backend_dataset_h5necdf
-    cfgrib = xarray.backends.cfgrib_:open_backend_dataset_cfgrib
+    zarr = xarray.backends.zarr:zarr_backend
+    h5netcdf = xarray.backends.h5netcdf_:h5netcdf_backend
+    cfgrib = xarray.backends.cfgrib_:cfgrib_backend
 
 [options.extras_require]
 io =

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -14,8 +14,7 @@ from .pydap_ import PydapDataStore
 from .pynio_ import NioDataStore
 from .scipy_ import ScipyDataStore
 from .zarr import ZarrStore
-from .plugins import ENGINES
-
+from .plugins import detect_engines
 __all__ = [
     "AbstractDataStore",
     "FileManager",

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -9,12 +9,13 @@ from .file_manager import CachingFileManager, DummyFileManager, FileManager
 from .h5netcdf_ import H5NetCDFStore
 from .memory import InMemoryDataStore
 from .netCDF4_ import NetCDF4DataStore
+from .plugins import detect_engines
 from .pseudonetcdf_ import PseudoNetCDFDataStore
 from .pydap_ import PydapDataStore
 from .pynio_ import NioDataStore
 from .scipy_ import ScipyDataStore
 from .zarr import ZarrStore
-from .plugins import detect_engines
+
 __all__ = [
     "AbstractDataStore",
     "FileManager",

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -14,6 +14,7 @@ from .pydap_ import PydapDataStore
 from .pynio_ import NioDataStore
 from .scipy_ import ScipyDataStore
 from .zarr import ZarrStore
+from .plugins import ENGINES
 
 __all__ = [
     "AbstractDataStore",

--- a/xarray/backends/__init__.py
+++ b/xarray/backends/__init__.py
@@ -30,4 +30,5 @@ __all__ = [
     "H5NetCDFStore",
     "ZarrStore",
     "PseudoNetCDFDataStore",
+    "detect_engines",
 ]

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -437,7 +437,7 @@ def open_dataset(
         kwargs = locals().copy()
         from . import apiv2, plugins
 
-        if engine in plugins.ENGINES:
+        if engine in plugins.detect_engines():
             return apiv2.open_dataset(**kwargs)
 
     if autoclose is not None:

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -218,9 +218,9 @@ def open_dataset(
     if engine is None:
         engine = _autodetect_engine(filename_or_obj)
 
-    backend = _get_backend_cls(engine, engines=plugins.ENGINES)
-    open_backend_dataset = backend["open_dataset"]
-    open_backend_dataset_parameters = backend["open_dataset_parameters"]
+    backend = _get_backend_cls(engine, engines=plugins.detect_engines())
+    open_backend_dataset = backend.open_dataset
+    open_backend_dataset_parameters = backend.open_dataset_parameters
 
     decoders = resolve_decoders_kwargs(
         decode_cf,

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -2,11 +2,7 @@ import os
 
 from ..core.utils import is_remote_uri
 from . import plugins, zarr
-from .api import (
-    _autodetect_engine,
-    _normalize_path,
-    _protect_dataset_variables_inplace,
-)
+from .api import _autodetect_engine, _normalize_path, _protect_dataset_variables_inplace
 
 
 def _get_backend_cls(engine):
@@ -245,9 +241,7 @@ def open_dataset(
     backend_kwargs = backend_kwargs.copy()
     overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
 
-    open_backend_dataset = _get_backend_cls(engine)[
-        "open_dataset"
-    ]
+    open_backend_dataset = _get_backend_cls(engine)["open_dataset"]
     backend_ds = open_backend_dataset(
         filename_or_obj,
         drop_variables=drop_variables,

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -4,10 +4,22 @@ from ..core.utils import is_remote_uri
 from . import plugins, zarr
 from .api import (
     _autodetect_engine,
-    _get_backend_cls,
     _normalize_path,
     _protect_dataset_variables_inplace,
 )
+
+
+def _get_backend_cls(engine):
+    """Select open_dataset method based on current engine"""
+
+    try:
+        return plugins.ENGINES[engine]
+    except KeyError:
+        all_plugins = plugins.ENGINES.keys()
+        raise ValueError(
+            "unrecognized engine for open_dataset: {}\n"
+            "must be one of: {}".format(engine, list(all_plugins))
+        )
 
 
 def dataset_from_backend_dataset(
@@ -233,7 +245,7 @@ def open_dataset(
     backend_kwargs = backend_kwargs.copy()
     overwrite_encoded_chunks = backend_kwargs.pop("overwrite_encoded_chunks", None)
 
-    open_backend_dataset = _get_backend_cls(engine, engines=plugins.ENGINES)[
+    open_backend_dataset = _get_backend_cls(engine)[
         "open_dataset"
     ]
     backend_ds = open_backend_dataset(

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -9,7 +9,6 @@ from .common import AbstractDataStore, BackendArray
 from .locks import SerializableLock, ensure_lock
 from .plugins import BackendEntrypoint
 
-
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
 #       https://confluence.ecmwf.int/display/ECC/Frequently+Asked+Questions
@@ -129,4 +128,5 @@ def open_backend_dataset_cfgrib(
 
     return ds
 
-cfgrib_backend =  BackendEntrypoint(open_dataset=open_backend_dataset_cfgrib)
+
+cfgrib_backend = BackendEntrypoint(open_dataset=open_backend_dataset_cfgrib)

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -7,6 +7,8 @@ from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray
 from .locks import SerializableLock, ensure_lock
+from .plugins import BackendEntrypoint
+
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
@@ -127,4 +129,4 @@ def open_backend_dataset_cfgrib(
 
     return ds
 
-cfgrib_backend = {'open_dataset': open_backend_dataset_cfgrib}
+cfgrib_backend =  BackendEntrypoint(open_dataset=open_backend_dataset_cfgrib)

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -126,3 +126,5 @@ def open_backend_dataset_cfgrib(
         ds.encoding = encoding
 
     return ds
+
+cfgrib_backend = {'open_dataset': open_backend_dataset_cfgrib}

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -18,6 +18,8 @@ from .netCDF4_ import (
     _get_datatype,
     _nc4_require_group,
 )
+from .plugins import BackendEntrypoint
+
 
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
@@ -376,4 +378,4 @@ def open_backend_dataset_h5netcdf(
     return ds
 
 
-h5netcdf_backend = {'open_dataset': open_backend_dataset_h5netcdf}
+h5netcdf_backend = BackendEntrypoint(open_dataset=open_backend_dataset_h5netcdf)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -21,7 +21,6 @@ from .netCDF4_ import (
 from .plugins import BackendEntrypoint
 
 
-
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
     def get_array(self, needs_lock=True):
         ds = self.datastore._acquire(needs_lock)

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -325,7 +325,7 @@ class H5NetCDFStore(WritableCFDataStore):
         self._manager.close(**kwargs)
 
 
-def open_backend_dataset_h5necdf(
+def open_backend_dataset_h5netcdf(
     filename_or_obj,
     *,
     mask_and_scale=True,
@@ -374,3 +374,6 @@ def open_backend_dataset_h5necdf(
         ds.encoding = encoding
 
     return ds
+
+
+h5netcdf_backend = {'open_dataset': open_backend_dataset_h5netcdf}

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -4,10 +4,12 @@ import typing as T
 import warnings
 from functools import lru_cache
 
-import entrypoints # type: ignore
+import entrypoints  # type: ignore
 
 
 class BackendEntrypoint:
+    __slots__ = ("open_dataset", "open_dataset_parameters")
+
     def __init__(self, open_dataset, open_dataset_parameters=None):
         self.open_dataset = open_dataset
         self.open_dataset_parameters = open_dataset_parameters

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,17 +1,20 @@
 import inspect
 import typing as T
+import entrypoints
+import sys
 
-from . import cfgrib_, h5netcdf_, zarr
+path = sys.path.copy()
+path = set(path)
 
 ENGINES: T.Dict[str, T.Dict[str, T.Any]] = {
     "h5netcdf": {
-        "open_dataset": h5netcdf_.open_backend_dataset_h5necdf,
+        "open_dataset": entrypoints.get_single("xarray.backends", "h5netcdf", path=path).load(),
     },
     "zarr": {
-        "open_dataset": zarr.open_backend_dataset_zarr,
+        "open_dataset": entrypoints.get_single("xarray.backends", "zarr", path=path).load(),
     },
     "cfgrib": {
-        "open_dataset": cfgrib_.open_backend_dataset_cfgrib,
+        "open_dataset": entrypoints.get_single("xarray.backends", "cfgrib", path=path).load(),
     },
 }
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -24,20 +24,13 @@ def filter_unique_ids(backend_entrypoints):
     return backend_entrypoints_unique
 
 
-def warning_on_entrypoints_conflict(
-        backend_entrypoints,
-        backend_entrypoints_all
-):
+def warning_on_entrypoints_conflict(backend_entrypoints, backend_entrypoints_all):
 
     # sort and group entrypoints by name
     key_name = lambda ep: ep.name
-    backend_entrypoints_all_unique_ids = sorted(
-        backend_entrypoints_all,
-        key=key_name
-    )
+    backend_entrypoints_all_unique_ids = sorted(backend_entrypoints_all, key=key_name)
     backend_entrypoints_ids_grouped = itertools.groupby(
-        backend_entrypoints_all_unique_ids,
-        key=key_name
+        backend_entrypoints_all_unique_ids, key=key_name
     )
 
     # check if there are multiple entrypoints for the same name
@@ -62,22 +55,19 @@ def detect_parameters(open_dataset):
             inspect.Parameter.VAR_POSITIONAL,
         ):
             raise TypeError(
-                f'All the parameters in {open_dataset!r} signature should be explicit. '
+                f"All the parameters in {open_dataset!r} signature should be explicit. "
                 "*args and **kwargs is not supported"
             )
     return set(parameters)
 
 
 def detect_engines():
-    backend_entrypoints = entrypoints.get_group_named('xarray.backends')
-    backend_entrypoints_all = entrypoints.get_group_all('xarray.backends')
+    backend_entrypoints = entrypoints.get_group_named("xarray.backends")
+    backend_entrypoints_all = entrypoints.get_group_all("xarray.backends")
     backend_entrypoints_all = filter_unique_ids(backend_entrypoints_all)
 
     if len(backend_entrypoints_all) != len(backend_entrypoints):
-        warning_on_entrypoints_conflict(
-            backend_entrypoints,
-            backend_entrypoints_all
-        )
+        warning_on_entrypoints_conflict(backend_entrypoints, backend_entrypoints_all)
 
     engines: T.Dict[str, T.Dict[str, T.Any]] = {}
     for name, backend in backend_entrypoints.items():
@@ -87,10 +77,8 @@ def detect_engines():
         open_dataset = backend["open_dataset"]
         if "signature" in backend:
             pass
-        backend['open_dataset_parameters'] = detect_parameters(open_dataset)
+        backend["open_dataset_parameters"] = detect_parameters(open_dataset)
     return engines
 
 
 ENGINES = detect_engines()
-
-

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -1,34 +1,96 @@
 import inspect
+import itertools
 import typing as T
+import warnings
+
 import entrypoints
-import sys
-
-path = sys.path.copy()
-path = set(path)
-
-ENGINES: T.Dict[str, T.Dict[str, T.Any]] = {
-    "h5netcdf": {
-        "open_dataset": entrypoints.get_single("xarray.backends", "h5netcdf", path=path).load(),
-    },
-    "zarr": {
-        "open_dataset": entrypoints.get_single("xarray.backends", "zarr", path=path).load(),
-    },
-    "cfgrib": {
-        "open_dataset": entrypoints.get_single("xarray.backends", "cfgrib", path=path).load(),
-    },
-}
 
 
-for engine in ENGINES.values():
-    if "signature" not in engine:
-        parameters = inspect.signature(engine["open_dataset"]).parameters
-        for name, param in parameters.items():
-            if param.kind in (
-                inspect.Parameter.VAR_KEYWORD,
-                inspect.Parameter.VAR_POSITIONAL,
-            ):
-                raise TypeError(
-                    f'All the parameters in {engine["open_dataset"]!r} signature should be explicit. '
-                    "*args and **kwargs is not supported"
-                )
-        engine["signature"] = set(parameters)
+def get_entrypoint_id(entrypoint):
+    name = entrypoint.name
+    obj = entrypoint.object_name or ""
+    module = entrypoint.module_name
+    return (name, f"{module}:{obj}")
+
+
+def filter_unique_ids(backend_entrypoints):
+    entrypoints_id = set()
+    backend_entrypoints_unique = []
+    for entrypoint in backend_entrypoints:
+        id = get_entrypoint_id(entrypoint)
+        if id not in entrypoints_id:
+            backend_entrypoints_unique.append(entrypoint)
+            entrypoints_id.add(id)
+    return backend_entrypoints_unique
+
+
+def warning_on_entrypoints_conflict(
+        backend_entrypoints,
+        backend_entrypoints_all
+):
+
+    # sort and group entrypoints by name
+    key_name = lambda ep: ep.name
+    backend_entrypoints_all_unique_ids = sorted(
+        backend_entrypoints_all,
+        key=key_name
+    )
+    backend_entrypoints_ids_grouped = itertools.groupby(
+        backend_entrypoints_all_unique_ids,
+        key=key_name
+    )
+
+    # check if there are multiple entrypoints for the same name
+    for name, matches in backend_entrypoints_ids_grouped:
+        matches = list(matches)
+        matches_len = len(matches)
+        if matches_len > 1:
+            selected_entrypoint = backend_entrypoints[name]
+            warnings.warn(
+                f"\nFound {matches_len} entrypoints "
+                f"for the engine name {name}:\n {matches}.\n"
+                f"It will be used: {selected_entrypoint}.",
+            )
+
+
+def detect_parameters(open_dataset):
+    signature = inspect.signature(open_dataset)
+    parameters = signature.parameters
+    for name, param in parameters.items():
+        if param.kind in (
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            raise TypeError(
+                f'All the parameters in {open_dataset!r} signature should be explicit. '
+                "*args and **kwargs is not supported"
+            )
+    return set(parameters)
+
+
+def detect_engines():
+    backend_entrypoints = entrypoints.get_group_named('xarray.backends')
+    backend_entrypoints_all = entrypoints.get_group_all('xarray.backends')
+    backend_entrypoints_all = filter_unique_ids(backend_entrypoints_all)
+
+    if len(backend_entrypoints_all) != len(backend_entrypoints):
+        warning_on_entrypoints_conflict(
+            backend_entrypoints,
+            backend_entrypoints_all
+        )
+
+    engines: T.Dict[str, T.Dict[str, T.Any]] = {}
+    for name, backend in backend_entrypoints.items():
+        backend = backend.load()
+        engines[name] = backend
+
+        open_dataset = backend["open_dataset"]
+        if "signature" in backend:
+            pass
+        backend['open_dataset_parameters'] = detect_parameters(open_dataset)
+    return engines
+
+
+ENGINES = detect_engines()
+
+

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -741,3 +741,5 @@ def open_backend_dataset_zarr(
         ds.encoding = encoding
 
     return ds
+
+zarr_backend = {'open_dataset': open_backend_dataset_zarr}

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -9,6 +9,7 @@ from ..core.pycompat import integer_types
 from ..core.utils import FrozenDict, HiddenKeyDict, close_on_error
 from ..core.variable import Variable
 from .common import AbstractWritableDataStore, BackendArray, _encode_variable_name
+from .plugins import BackendEntrypoint
 
 # need some special secret attributes to tell us the dimensions
 DIMENSION_KEY = "_ARRAY_DIMENSIONS"
@@ -742,4 +743,4 @@ def open_backend_dataset_zarr(
 
     return ds
 
-zarr_backend = {'open_dataset': open_backend_dataset_zarr}
+zarr_backend = BackendEntrypoint(open_dataset= open_backend_dataset_zarr)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -743,4 +743,5 @@ def open_backend_dataset_zarr(
 
     return ds
 
-zarr_backend = BackendEntrypoint(open_dataset= open_backend_dataset_zarr)
+
+zarr_backend = BackendEntrypoint(open_dataset=open_backend_dataset_zarr)


### PR DESCRIPTION
Add entrypoints in setup.cfg and Use plugins.py file to retrive engines. 

 - [x] Part of issue #3166
 - [x] Passes `isort . && black 
 - [x] Passes all tests for backends
