### PR TITLE
Refactor apiv2 open dataset

### DIFF
--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -64,7 +64,7 @@ def _chunk_ds(
     return ds
 
 
-def dataset_from_backend_dataset(
+def _dataset_from_backend_dataset(
     backend_ds,
     filename_or_obj,
     engine,
@@ -103,7 +103,7 @@ def dataset_from_backend_dataset(
     return ds
 
 
-def resolve_decoders_kwargs(decode_cf, engine, **decoders):
+def _resolve_decoders_kwargs(decode_cf, engine, **decoders):
     signature = plugins.ENGINES[engine]["signature"]
     if decode_cf is False:
         for d in decoders:
@@ -250,7 +250,7 @@ def open_dataset(
     if engine is None:
         engine = _autodetect_engine(filename_or_obj)
 
-    decoders = resolve_decoders_kwargs(
+    decoders = _resolve_decoders_kwargs(
         decode_cf,
         engine=engine,
         mask_and_scale=mask_and_scale,
@@ -274,7 +274,7 @@ def open_dataset(
         **backend_kwargs,
         **{k: v for k, v in kwargs.items() if v is not None},
     )
-    ds = dataset_from_backend_dataset(
+    ds = _dataset_from_backend_dataset(
         backend_ds,
         filename_or_obj,
         engine,


### PR DESCRIPTION
Related to PR https://github.com/pydata/xarray/pull/4595.
In this smaller PR there aren't changes in xarry interfaces, it's only a small code refactor needed to simplify https://github.com/pydata/xarray/pull/4595.
No functional changes, that's only a refactor a style fix.
in apiv2.dataset_from_backend_dataset:
- rename ds in backend_ds and ds2 in ds.
- simplify if for in chunking and split code adding function _chunks_ds
- add _get_mtime specific function
And  
make resolve_decoders_kwargs and dataset_from_backend_dataset private
 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
