### PR TITLE
Modify zarr chunking as suggested in pydata#4496 v2

### DIFF
--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -377,10 +377,12 @@ def open_dataset(
         "netcdf4".
     chunks : int or dict, optional
         If chunks is provided, it is used to load the new dataset into dask
-        arrays. ``chunks={}`` loads the dataset with dask using a single
-        chunk for all arrays. When using ``engine="zarr"``, setting
-        ``chunks='auto'`` will create dask chunks based on the variable's zarr
-        chunks.
+        arrays. ``chunks=-1`` loads the dataset with dask using a single
+        chunk for all arrays. `chunks={}`` loads the dataset with dask using
+        engine preferred chunks if exposed by the backend, otherwise with
+        a single chunk for all arrays.
+        ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
+        engine preferred chunks. See dask chunking for more details.
     lock : False or lock-like, optional
         Resource lock to use when reading data from disk. Only relevant when
         using dask or another form of parallelism. By default, appropriate

--- a/xarray/backends/api.py
+++ b/xarray/backends/api.py
@@ -536,7 +536,7 @@ def open_dataset(
                 k: _maybe_chunk(
                     k,
                     v,
-                    _get_chunk(k, v, chunks),
+                    _get_chunk(v, chunks),
                     overwrite_encoded_chunks=overwrite_encoded_chunks,
                 )
                 for k, v in ds.variables.items()

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -146,10 +146,12 @@ def open_dataset(
         "pynio", "cfgrib", "pseudonetcdf", "zarr"}.
     chunks : int or dict, optional
         If chunks is provided, it is used to load the new dataset into dask
-        arrays. ``chunks={}`` loads the dataset with dask using a single
-        chunk for all arrays. When using ``engine="zarr"``, setting
-        ``chunks='auto'`` will create dask chunks based on the variable's zarr
-        chunks.
+        arrays. ``chunks=-1`` loads the dataset with dask using a single
+        chunk for all arrays. `chunks={}`` loads the dataset with dask using
+        engine preferred chunks if exposed by the backend, otherwise with
+        a single chunk for all arrays.
+        ``chunks='auto'`` will use dask ``auto`` chunking taking into account the
+        engine preferred chunks. See dask chunking for more details.
     cache : bool, optional
         If True, cache data is loaded from the underlying datastore in memory as
         NumPy arrays when accessed to avoid reading from the underlying data-

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -53,7 +53,7 @@ def _chunk_ds(
 
         variables = {}
         for k, v in backend_ds.variables.items():
-            var_chunks = _get_chunk(k, v, chunks)
+            var_chunks = _get_chunk(v, chunks)
             variables[k] = _maybe_chunk(
                 k,
                 v,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -611,6 +611,14 @@ def open_zarr(
     """
     from .api import open_dataset
 
+    if chunks == "auto":
+        try:
+            import dask.array  # noqa
+
+            chunks = {}
+        except ImportError:
+            chunks = None
+
     if kwargs:
         raise TypeError(
             "open_zarr() got unexpected keyword arguments " + ",".join(kwargs.keys())

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -414,10 +414,6 @@ def _maybe_chunk(
         # subtle bugs result otherwise. see GH3350
         token2 = tokenize(name, token if token else var._data, chunks)
         name2 = f"{name_prefix}{name}-{token2}"
-        import pdb
-
-        pdb.set_trace()
-
         var = var.chunk(chunks, name=name2, lock=lock, use_preferred_chunks=True)
 
         if overwrite_encoded_chunks and var.chunks is not None:


### PR DESCRIPTION
Part of https://github.com/pydata/xarray/pull/4595
The changes involve currently only `open_dataset(..., engine=zarr)` (and marginally `open_zarr`), in particular:
- `_get_chunks`
- variable.chunks (add a key `use_preferred_chunks` used only for `open_dataset(engine=zarr)`) 

have been modified to fit #4496 (comment) option 1 chunking behaviour and align open_dataset chunking with `dataset.chunk`:

- with `auto` it uses dask auto-chunking (if a preferred_chunking is defined, dask will take it into account as done in `dataset.chunk`)
- with `-1` it uses dask but no chunking.
- with `{}` it uses the backend encoded chunks (when available) for on-disk data (`xr.open_dataset`) and the current chunking for already opened datasets (`ds.chunk`)

Add some test
 - [x] Releted to pydata#4496
 - [x] Tests added
 - [x] Passes `isort . && black . && mypy . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
