### PR TITLE
WIP: Replace backend entrypoints with abstract backend entrypoint

### DIFF
--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -237,7 +237,6 @@ def open_dataset(
     --------
     open_mfdataset
     """
-
     if cache is None:
         cache = chunks is None
 

--- a/xarray/backends/apiv2.py
+++ b/xarray/backends/apiv2.py
@@ -237,6 +237,7 @@ def open_dataset(
     --------
     open_mfdataset
     """
+
     if cache is None:
         cache = chunks is None
 

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
-from .common import AbstractDataStore, BackendArray, BackendEntrypoint
+from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .locks import SerializableLock, ensure_lock
 from .store import open_backend_dataset_store
 
@@ -74,58 +74,55 @@ class CfGribDataStore(AbstractDataStore):
         return encoding
 
 
-def guess_can_open_cfgrib(store_spec):
-    try:
-        _, ext = os.path.splitext(store_spec)
-    except TypeError:
-        return False
-    return ext in {".grib", ".grib2", ".grb", ".grb2"}
+class CfgribfBackendEntrypoint(AbstractBackendEntrypoint):
 
+    def guess_can_open_cfgrib(store_spec):
+        try:
+            _, ext = os.path.splitext(store_spec)
+        except TypeError:
+            return False
+        return ext in {".grib", ".grib2", ".grb", ".grb2"}
 
-def open_backend_dataset_cfgrib(
-    filename_or_obj,
-    *,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    lock=None,
-    indexpath="{path}.{short_hash}.idx",
-    filter_by_keys={},
-    read_keys=[],
-    encode_cf=("parameter", "time", "geography", "vertical"),
-    squeeze=True,
-    time_dims=("time", "step"),
-):
+    def open_backend_dataset_cfgrib(
+            filename_or_obj,
+            *,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            lock=None,
+            indexpath="{path}.{short_hash}.idx",
+            filter_by_keys={},
+            read_keys=[],
+            encode_cf=("parameter", "time", "geography", "vertical"),
+            squeeze=True,
+            time_dims=("time", "step"),
+    ):
 
-    store = CfGribDataStore(
-        filename_or_obj,
-        indexpath=indexpath,
-        filter_by_keys=filter_by_keys,
-        read_keys=read_keys,
-        encode_cf=encode_cf,
-        squeeze=squeeze,
-        time_dims=time_dims,
-        lock=lock,
-    )
-
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+        store = CfGribDataStore(
+            filename_or_obj,
+            indexpath=indexpath,
+            filter_by_keys=filter_by_keys,
+            read_keys=read_keys,
+            encode_cf=encode_cf,
+            squeeze=squeeze,
+            time_dims=time_dims,
+            lock=lock,
         )
-    return ds
 
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds
 
-cfgrib_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_cfgrib, guess_can_open=guess_can_open_cfgrib
-)

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -9,7 +9,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
 )
 from .locks import SerializableLock, ensure_lock
 from .store import StoreBackendEntrypoint
@@ -86,7 +86,7 @@ class CfGribDataStore(AbstractDataStore):
         return encoding
 
 
-class CfgribfBackendEntrypoint(AbstractBackendEntrypoint):
+class CfgribfBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         try:

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -87,7 +87,6 @@ class CfGribDataStore(AbstractDataStore):
 
 
 class CfgribfBackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         try:
             _, ext = os.path.splitext(store_spec)
@@ -96,23 +95,23 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
         return ext in {".grib", ".grib2", ".grb", ".grb2"}
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            *,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            lock=None,
-            indexpath="{path}.{short_hash}.idx",
-            filter_by_keys={},
-            read_keys=[],
-            encode_cf=("parameter", "time", "geography", "vertical"),
-            squeeze=True,
-            time_dims=("time", "step"),
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        lock=None,
+        indexpath="{path}.{short_hash}.idx",
+        filter_by_keys={},
+        read_keys=[],
+        encode_cf=("parameter", "time", "geography", "vertical"),
+        squeeze=True,
+        time_dims=("time", "step"),
     ):
 
         store = CfGribDataStore(
@@ -138,7 +137,6 @@ class CfgribfBackendEntrypoint(BackendEntrypoint):
                 decode_timedelta=decode_timedelta,
             )
         return ds
-
 
 
 if has_cfgrib:

--- a/xarray/backends/cfgrib_.py
+++ b/xarray/backends/cfgrib_.py
@@ -7,7 +7,7 @@ from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .locks import SerializableLock, ensure_lock
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 # FIXME: Add a dedicated lock, even if ecCodes is supposed to be thread-safe
 #   in most circumstances. See:
@@ -76,14 +76,15 @@ class CfGribDataStore(AbstractDataStore):
 
 class CfgribfBackendEntrypoint(AbstractBackendEntrypoint):
 
-    def guess_can_open_cfgrib(store_spec):
+    def guess_can_open(self, store_spec):
         try:
             _, ext = os.path.splitext(store_spec)
         except TypeError:
             return False
         return ext in {".grib", ".grib2", ".grb", ".grb2"}
 
-    def open_backend_dataset_cfgrib(
+    def open_dataset(
+            self,
             filename_or_obj,
             *,
             mask_and_scale=True,
@@ -112,9 +113,9 @@ class CfgribfBackendEntrypoint(AbstractBackendEntrypoint):
             time_dims=time_dims,
             lock=lock,
         )
-
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -2,7 +2,6 @@ import logging
 import time
 import traceback
 from typing import Dict
-from abc import ABC, abstractmethod
 
 import numpy as np
 
@@ -344,10 +343,9 @@ class WritableCFDataStore(AbstractWritableDataStore):
         return variables, attributes
 
 
-class AbstractBackendEntrypoint(ABC):
+class BackendEntrypoint():
     open_dataset_parameters = None
 
-    @abstractmethod
     def open_dataset(self):
         pass
 
@@ -356,4 +354,4 @@ class AbstractBackendEntrypoint(ABC):
 
 
 
-BACKEND_ENTRYPOINTS: Dict[str, AbstractBackendEntrypoint] = {}
+BACKEND_ENTRYPOINTS: Dict[str, BackendEntrypoint] = {}

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import traceback
+from abc import ABC, abstractmethod
 
 import numpy as np
 
@@ -342,10 +343,19 @@ class WritableCFDataStore(AbstractWritableDataStore):
         return variables, attributes
 
 
-class BackendEntrypoint:
+class AbstractBackendEntrypoint(ABC):
     __slots__ = ("guess_can_open", "open_dataset", "open_dataset_parameters")
 
-    def __init__(self, open_dataset, open_dataset_parameters=None, guess_can_open=None):
-        self.open_dataset = open_dataset
-        self.open_dataset_parameters = open_dataset_parameters
-        self.guess_can_open = guess_can_open
+
+    open_dataset_parameters = None
+
+
+    @abstractmethod
+    def open_dataset(self):
+        pass
+
+
+    @abstractmethod
+    def guess_can_open(self, store_spec):
+        pass
+

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -344,18 +344,12 @@ class WritableCFDataStore(AbstractWritableDataStore):
 
 
 class AbstractBackendEntrypoint(ABC):
-    __slots__ = ("guess_can_open", "open_dataset", "open_dataset_parameters")
-
-
     open_dataset_parameters = None
-
 
     @abstractmethod
     def open_dataset(self):
         pass
 
-
-    @abstractmethod
     def guess_can_open(self, store_spec):
-        pass
+        return False
 

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import traceback
-from typing import Dict
+from typing import Dict, Tuple, Type, Union
 
 import numpy as np
 
@@ -343,8 +343,8 @@ class WritableCFDataStore(AbstractWritableDataStore):
         return variables, attributes
 
 
-class BackendEntrypoint():
-    open_dataset_parameters = None
+class BackendEntrypoint:
+    open_dataset_parameters: Union[Tuple, None] = None
 
     def open_dataset(self):
         pass
@@ -353,5 +353,4 @@ class BackendEntrypoint():
         return False
 
 
-
-BACKEND_ENTRYPOINTS: Dict[str, BackendEntrypoint] = {}
+BACKEND_ENTRYPOINTS: Dict[str, Type[BackendEntrypoint]] = {}

--- a/xarray/backends/common.py
+++ b/xarray/backends/common.py
@@ -347,7 +347,7 @@ class BackendEntrypoint:
     open_dataset_parameters: Union[Tuple, None] = None
 
     def open_dataset(self):
-        pass
+        raise NotImplementedError
 
     def guess_can_open(self, store_spec):
         return False

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -18,7 +18,7 @@ from .netCDF4_ import (
     _get_datatype,
     _nc4_require_group,
 )
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 
 class H5NetCDFArrayWrapper(BaseNetCDF4Array):
@@ -321,7 +321,7 @@ class H5NetCDFStore(WritableCFDataStore):
 
 class H5netcdfBackendEntrypoint(AbstractBackendEntrypoint):
 
-    def guess_can_open_h5netcdf(store_spec):
+    def guess_can_open(self, store_spec):
         try:
             return read_magic_number(store_spec).startswith(b"\211HDF\r\n\032\n")
         except TypeError:
@@ -334,7 +334,8 @@ class H5netcdfBackendEntrypoint(AbstractBackendEntrypoint):
 
         return ext in {".nc", ".nc4", ".cdf"}
 
-    def open_backend_dataset_h5netcdf(
+    def open_dataset(
+            self,
             filename_or_obj,
             *,
             mask_and_scale=True,
@@ -360,7 +361,9 @@ class H5netcdfBackendEntrypoint(AbstractBackendEntrypoint):
             phony_dims=phony_dims,
         )
 
-        ds = open_backend_dataset_store(
+        store_entrypoint = StoreBackendEntrypoint()
+
+        ds = store_entrypoint.open_dataset(
             store,
             mask_and_scale=mask_and_scale,
             decode_times=decode_times,

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -10,7 +10,7 @@ from ..core.utils import FrozenDict, is_remote_uri, read_magic_number
 from ..core.variable import Variable
 from .common import (
     BACKEND_ENTRYPOINTS,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
     WritableCFDataStore,
     find_root_and_group,
 )
@@ -328,7 +328,7 @@ class H5NetCDFStore(WritableCFDataStore):
         self._manager.close(**kwargs)
 
 
-class H5netcdfBackendEntrypoint(AbstractBackendEntrypoint):
+class H5netcdfBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         try:

--- a/xarray/backends/h5netcdf_.py
+++ b/xarray/backends/h5netcdf_.py
@@ -329,7 +329,6 @@ class H5NetCDFStore(WritableCFDataStore):
 
 
 class H5netcdfBackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         try:
             return read_magic_number(store_spec).startswith(b"\211HDF\r\n\032\n")
@@ -344,21 +343,21 @@ class H5netcdfBackendEntrypoint(BackendEntrypoint):
         return ext in {".nc", ".nc4", ".cdf"}
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            *,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            format=None,
-            group=None,
-            lock=None,
-            invalid_netcdf=None,
-            phony_dims=None,
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        format=None,
+        group=None,
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims=None,
     ):
 
         store = H5NetCDFStore.open(

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -513,7 +513,6 @@ class NetCDF4DataStore(WritableCFDataStore):
 
 
 class NetCDF4BackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         if isinstance(store_spec, str) and is_remote_uri(store_spec):
             return True
@@ -524,23 +523,23 @@ class NetCDF4BackendEntrypoint(BackendEntrypoint):
         return ext in {".nc", ".nc4", ".cdf"}
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            group=None,
-            mode="r",
-            format="NETCDF4",
-            clobber=True,
-            diskless=False,
-            persist=False,
-            lock=None,
-            autoclose=False,
+        self,
+        filename_or_obj,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        group=None,
+        mode="r",
+        format="NETCDF4",
+        clobber=True,
+        diskless=False,
+        persist=False,
+        lock=None,
+        autoclose=False,
     ):
 
         store = NetCDF4DataStore.open(

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -13,7 +13,7 @@ from ..core.utils import FrozenDict, close_on_error, is_remote_uri
 from ..core.variable import Variable
 from .common import (
     BackendArray,
-    BackendEntrypoint,
+    AbstractBackendEntrypoint,
     WritableCFDataStore,
     find_root_and_group,
     robust_getitem,
@@ -505,61 +505,57 @@ class NetCDF4DataStore(WritableCFDataStore):
         self._manager.close(**kwargs)
 
 
-def guess_can_open_netcdf4(store_spec):
-    if isinstance(store_spec, str) and is_remote_uri(store_spec):
-        return True
-    try:
-        _, ext = os.path.splitext(store_spec)
-    except TypeError:
-        return False
-    return ext in {".nc", ".nc4", ".cdf"}
+class NetCDF4BackendEntrypoint(AbstractBackendEntrypoint):
 
+    def guess_can_open_netcdf4(store_spec):
+        if isinstance(store_spec, str) and is_remote_uri(store_spec):
+            return True
+        try:
+            _, ext = os.path.splitext(store_spec)
+        except TypeError:
+            return False
+        return ext in {".nc", ".nc4", ".cdf"}
 
-def open_backend_dataset_netcdf4(
-    filename_or_obj,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    group=None,
-    mode="r",
-    format="NETCDF4",
-    clobber=True,
-    diskless=False,
-    persist=False,
-    lock=None,
-    autoclose=False,
-):
+    def open_backend_dataset_netcdf4(
+            filename_or_obj,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            group=None,
+            mode="r",
+            format="NETCDF4",
+            clobber=True,
+            diskless=False,
+            persist=False,
+            lock=None,
+            autoclose=False,
+    ):
 
-    store = NetCDF4DataStore.open(
-        filename_or_obj,
-        mode=mode,
-        format=format,
-        group=group,
-        clobber=clobber,
-        diskless=diskless,
-        persist=persist,
-        lock=lock,
-        autoclose=autoclose,
-    )
-
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+        store = NetCDF4DataStore.open(
+            filename_or_obj,
+            mode=mode,
+            format=format,
+            group=group,
+            clobber=clobber,
+            diskless=diskless,
+            persist=persist,
+            lock=lock,
+            autoclose=autoclose,
         )
-    return ds
 
-
-netcdf4_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_netcdf4, guess_can_open=guess_can_open_netcdf4
-)
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -14,7 +14,7 @@ from ..core.variable import Variable
 from .common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
     WritableCFDataStore,
     find_root_and_group,
     robust_getitem,
@@ -512,7 +512,7 @@ class NetCDF4DataStore(WritableCFDataStore):
         self._manager.close(**kwargs)
 
 
-class NetCDF4BackendEntrypoint(AbstractBackendEntrypoint):
+class NetCDF4BackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         if isinstance(store_spec, str) and is_remote_uri(store_spec):

--- a/xarray/backends/netCDF4_.py
+++ b/xarray/backends/netCDF4_.py
@@ -21,7 +21,7 @@ from .common import (
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock, get_write_lock
 from .netcdf3 import encode_nc3_attr_value, encode_nc3_variable
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 # This lookup table maps from dtype.byteorder to a readable endian
 # string used by netCDF4.
@@ -507,7 +507,7 @@ class NetCDF4DataStore(WritableCFDataStore):
 
 class NetCDF4BackendEntrypoint(AbstractBackendEntrypoint):
 
-    def guess_can_open_netcdf4(store_spec):
+    def guess_can_open(self, store_spec):
         if isinstance(store_spec, str) and is_remote_uri(store_spec):
             return True
         try:
@@ -516,7 +516,8 @@ class NetCDF4BackendEntrypoint(AbstractBackendEntrypoint):
             return False
         return ext in {".nc", ".nc4", ".cdf"}
 
-    def open_backend_dataset_netcdf4(
+    def open_dataset(
+            self,
             filename_or_obj,
             mask_and_scale=True,
             decode_times=None,
@@ -547,8 +548,9 @@ class NetCDF4BackendEntrypoint(AbstractBackendEntrypoint):
             autoclose=autoclose,
         )
 
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -36,6 +36,7 @@ def remove_duplicates(backend_entrypoints):
 def detect_parameters(open_dataset):
     signature = inspect.signature(open_dataset)
     parameters = signature.parameters
+    parameters_list = []
     for name, param in parameters.items():
         if param.kind in (
             inspect.Parameter.VAR_KEYWORD,
@@ -45,7 +46,9 @@ def detect_parameters(open_dataset):
                 f"All the parameters in {open_dataset!r} signature should be explicit. "
                 "*args and **kwargs is not supported"
             )
-    return tuple(parameters)
+        if name != "self":
+            parameters_list.append(name)
+    return tuple(parameters_list)
 
 
 def create_engines_dict(backend_entrypoints):
@@ -70,9 +73,10 @@ def build_engines(entrypoints):
     external_backend_entrypoints = create_engines_dict(pkg_entrypoints)
     backend_entrypoints.update(external_backend_entrypoints)
     set_missing_parameters(backend_entrypoints)
+    engines = {}
     for name, backend in backend_entrypoints.items():
-        backend_entrypoints[name] = backend()
-    return backend_entrypoints
+        engines[name] = backend()
+    return engines
 
 
 @functools.lru_cache(maxsize=1)

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -7,27 +7,27 @@ import warnings
 
 import pkg_resources
 
-from .cfgrib_ import cfgrib_backend
-from .common import BackendEntrypoint
-from .h5netcdf_ import h5netcdf_backend
-from .netCDF4_ import netcdf4_backend
-from .pseudonetcdf_ import pseudonetcdf_backend
-from .pydap_ import pydap_backend
-from .pynio_ import pynio_backend
-from .scipy_ import scipy_backend
-from .store import store_backend
-from .zarr import zarr_backend
+from .cfgrib_ import CfgribfBackendEntrypoint
+from .common import AbstractBackendEntrypoint
+from .h5netcdf_ import H5netcdfBackendEntrypoint
+from .netCDF4_ import NetCDF4BackendEntrypoint
+from .pseudonetcdf_ import PseudoNetCDFBackendEntrypoint
+from .pydap_ import PydapBackendEntrypoint
+from .pynio_ import PynioBackendEntrypoint
+from .scipy_ import ScipyBackendEntrypoint
+from .store import StoreBackendEntrypoint
+from .zarr import ZarrBackendEntrypoint
 
-BACKEND_ENTRYPOINTS: T.Dict[str, BackendEntrypoint] = {
-    "store": store_backend,
-    "netcdf4": netcdf4_backend,
-    "h5netcdf": h5netcdf_backend,
-    "scipy": scipy_backend,
-    "pseudonetcdf": pseudonetcdf_backend,
-    "zarr": zarr_backend,
-    "cfgrib": cfgrib_backend,
-    "pydap": pydap_backend,
-    "pynio": pynio_backend,
+BACKEND_ENTRYPOINTS: T.Dict[str, AbstractBackendEntrypoint] = {
+    "store": StoreBackendEntrypoint(),
+    "netcdf4": NetCDF4BackendEntrypoint(),
+    "h5netcdf": H5netcdfBackendEntrypoint(),
+    "scipy": ScipyBackendEntrypoint(),
+    "pseudonetcdf": PseudoNetCDFBackendEntrypoint(),
+    "zarr": ZarrBackendEntrypoint(),
+    "cfgrib": CfgribfBackendEntrypoint(),
+    "pydap": PydapBackendEntrypoint(),
+    "pynio": PynioBackendEntrypoint(),
 }
 
 

--- a/xarray/backends/plugins.py
+++ b/xarray/backends/plugins.py
@@ -57,8 +57,8 @@ def create_engines_dict(backend_entrypoints):
     return engines
 
 
-def set_missing_parameters(engines):
-    for name, backend in engines.items():
+def set_missing_parameters(backend_entrypoints):
+    for name, backend in backend_entrypoints.items():
         if backend.open_dataset_parameters is None:
             open_dataset = backend.open_dataset
             backend.open_dataset_parameters = detect_parameters(open_dataset)
@@ -70,6 +70,8 @@ def build_engines(entrypoints):
     external_backend_entrypoints = create_engines_dict(pkg_entrypoints)
     backend_entrypoints.update(external_backend_entrypoints)
     set_missing_parameters(backend_entrypoints)
+    for name, backend in backend_entrypoints.items():
+        backend_entrypoints[name] = backend()
     return backend_entrypoints
 
 

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
-from .common import AbstractDataStore, BackendArray, BackendEntrypoint
+from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock
 from .store import open_backend_dataset_store
@@ -88,53 +88,49 @@ class PseudoNetCDFDataStore(AbstractDataStore):
         self._manager.close()
 
 
-def open_backend_dataset_pseudonetcdf(
-    filename_or_obj,
-    mask_and_scale=False,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    mode=None,
-    lock=None,
-    **format_kwargs,
-):
+class PseudoNetCDFBackendEntrypoint(AbstractBackendEntrypoint):
 
-    store = PseudoNetCDFDataStore.open(
-        filename_or_obj, lock=lock, mode=mode, **format_kwargs
+    # *args and **kwargs are not allowed in open_backend_dataset_ kwargs,
+    # unless the open_dataset_parameters are explicity defined like this:
+    open_dataset_parameters = (
+        "filename_or_obj",
+        "mask_and_scale",
+        "decode_times",
+        "concat_characters",
+        "decode_coords",
+        "drop_variables",
+        "use_cftime",
+        "decode_timedelta",
+        "mode",
+        "lock",
     )
 
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+    def open_backend_dataset_pseudonetcdf(
+            filename_or_obj,
+            mask_and_scale=False,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            mode=None,
+            lock=None,
+            **format_kwargs,
+    ):
+        store = PseudoNetCDFDataStore.open(
+            filename_or_obj, lock=lock, mode=mode, **format_kwargs
         )
-    return ds
 
-
-# *args and **kwargs are not allowed in open_backend_dataset_ kwargs,
-# unless the open_dataset_parameters are explicity defined like this:
-open_dataset_parameters = (
-    "filename_or_obj",
-    "mask_and_scale",
-    "decode_times",
-    "concat_characters",
-    "decode_coords",
-    "drop_variables",
-    "use_cftime",
-    "decode_timedelta",
-    "mode",
-    "lock",
-)
-pseudonetcdf_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_pseudonetcdf,
-    open_dataset_parameters=open_dataset_parameters,
-)
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -6,7 +6,7 @@ from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 # psuedonetcdf can invoke netCDF libraries internally
 PNETCDF_LOCK = combine_locks([HDF5_LOCK, NETCDFC_LOCK])
@@ -105,7 +105,8 @@ class PseudoNetCDFBackendEntrypoint(AbstractBackendEntrypoint):
         "lock",
     )
 
-    def open_backend_dataset_pseudonetcdf(
+    def open_dataset(
+            self,
             filename_or_obj,
             mask_and_scale=False,
             decode_times=None,
@@ -122,8 +123,9 @@ class PseudoNetCDFBackendEntrypoint(AbstractBackendEntrypoint):
             filename_or_obj, lock=lock, mode=mode, **format_kwargs
         )
 
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -7,7 +7,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
 )
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, combine_locks, ensure_lock
@@ -100,7 +100,7 @@ class PseudoNetCDFDataStore(AbstractDataStore):
         self._manager.close()
 
 
-class PseudoNetCDFBackendEntrypoint(AbstractBackendEntrypoint):
+class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
 
     # *args and **kwargs are not allowed in open_backend_dataset_ kwargs,
     # unless the open_dataset_parameters are explicity defined like this:
@@ -151,4 +151,4 @@ class PseudoNetCDFBackendEntrypoint(AbstractBackendEntrypoint):
 
 
 if has_pseudonetcdf:
-    BACKEND_ENTRYPOINTS["pseudonetcdf"] = PseudoNetCDFDataStore
+    BACKEND_ENTRYPOINTS["pseudonetcdf"] = PseudoNetCDFBackendEntrypoint

--- a/xarray/backends/pseudonetcdf_.py
+++ b/xarray/backends/pseudonetcdf_.py
@@ -118,18 +118,18 @@ class PseudoNetCDFBackendEntrypoint(BackendEntrypoint):
     )
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            mask_and_scale=False,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            mode=None,
-            lock=None,
-            **format_kwargs,
+        self,
+        filename_or_obj,
+        mask_and_scale=False,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        mode=None,
+        lock=None,
+        **format_kwargs,
     ):
         store = PseudoNetCDFDataStore.open(
             filename_or_obj, lock=lock, mode=mode, **format_kwargs

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -8,7 +8,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
     robust_getitem,
 )
 from .store import StoreBackendEntrypoint
@@ -107,7 +107,7 @@ class PydapDataStore(AbstractDataStore):
         return Frozen(self.ds.dimensions)
 
 
-class PydapBackendEntrypoint(AbstractBackendEntrypoint):
+class PydapBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         return isinstance(store_spec, str) and is_remote_uri(store_spec)
@@ -145,4 +145,4 @@ class PydapBackendEntrypoint(AbstractBackendEntrypoint):
 
 
 if has_pydap:
-    BACKEND_ENTRYPOINTS["pydap"] = AbstractBackendEntrypoint
+    BACKEND_ENTRYPOINTS["pydap"] = PydapBackendEntrypoint

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -108,21 +108,20 @@ class PydapDataStore(AbstractDataStore):
 
 
 class PydapBackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         return isinstance(store_spec, str) and is_remote_uri(store_spec)
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            session=None,
+        self,
+        filename_or_obj,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        session=None,
     ):
         store = PydapDataStore.open(
             filename_or_obj,

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -5,7 +5,7 @@ from ..core.pycompat import integer_types
 from ..core.utils import Frozen, FrozenDict, close_on_error, is_dict_like, is_remote_uri
 from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint, robust_getitem
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 
 class PydapArrayWrapper(BackendArray):
@@ -97,10 +97,11 @@ class PydapDataStore(AbstractDataStore):
 
 class PydapBackendEntrypoint(AbstractBackendEntrypoint):
 
-    def guess_can_open_pydap(store_spec):
+    def guess_can_open(self, store_spec):
         return isinstance(store_spec, str) and is_remote_uri(store_spec)
 
-    def open_backend_dataset_pydap(
+    def open_dataset(
+            self,
             filename_or_obj,
             mask_and_scale=True,
             decode_times=None,
@@ -116,8 +117,9 @@ class PydapBackendEntrypoint(AbstractBackendEntrypoint):
             session=session,
         )
 
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/pydap_.py
+++ b/xarray/backends/pydap_.py
@@ -4,7 +4,7 @@ from ..core import indexing
 from ..core.pycompat import integer_types
 from ..core.utils import Frozen, FrozenDict, close_on_error, is_dict_like, is_remote_uri
 from ..core.variable import Variable
-from .common import AbstractDataStore, BackendArray, BackendEntrypoint, robust_getitem
+from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint, robust_getitem
 from .store import open_backend_dataset_store
 
 
@@ -95,41 +95,36 @@ class PydapDataStore(AbstractDataStore):
         return Frozen(self.ds.dimensions)
 
 
-def guess_can_open_pydap(store_spec):
-    return isinstance(store_spec, str) and is_remote_uri(store_spec)
+class PydapBackendEntrypoint(AbstractBackendEntrypoint):
 
+    def guess_can_open_pydap(store_spec):
+        return isinstance(store_spec, str) and is_remote_uri(store_spec)
 
-def open_backend_dataset_pydap(
-    filename_or_obj,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    session=None,
-):
-
-    store = PydapDataStore.open(
-        filename_or_obj,
-        session=session,
-    )
-
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+    def open_backend_dataset_pydap(
+            filename_or_obj,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            session=None,
+    ):
+        store = PydapDataStore.open(
+            filename_or_obj,
+            session=session,
         )
-        return ds
 
-
-pydap_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_pydap, guess_can_open=guess_can_open_pydap
-)
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+            return ds

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -6,7 +6,7 @@ from ..core.variable import Variable
 from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, SerializableLock, combine_locks, ensure_lock
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 # PyNIO can invoke netCDF libraries internally
 # Add a dedicated lock just in case NCL as well isn't thread-safe.
@@ -87,7 +87,7 @@ class NioDataStore(AbstractDataStore):
 
 class PynioBackendEntrypoint(AbstractBackendEntrypoint):
 
-    def open_backend_dataset_pynio(
+    def open_dataset(
             filename_or_obj,
             mask_and_scale=True,
             decode_times=None,
@@ -105,8 +105,9 @@ class PynioBackendEntrypoint(AbstractBackendEntrypoint):
             lock=lock,
         )
 
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..core import indexing
 from ..core.utils import Frozen, FrozenDict, close_on_error
 from ..core.variable import Variable
-from .common import AbstractDataStore, BackendArray, BackendEntrypoint
+from .common import AbstractDataStore, BackendArray, AbstractBackendEntrypoint
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, SerializableLock, combine_locks, ensure_lock
 from .store import open_backend_dataset_store
@@ -85,37 +85,36 @@ class NioDataStore(AbstractDataStore):
         self._manager.close()
 
 
-def open_backend_dataset_pynio(
-    filename_or_obj,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    mode="r",
-    lock=None,
-):
+class PynioBackendEntrypoint(AbstractBackendEntrypoint):
 
-    store = NioDataStore(
-        filename_or_obj,
-        mode=mode,
-        lock=lock,
-    )
-
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+    def open_backend_dataset_pynio(
+            filename_or_obj,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            mode="r",
+            lock=None,
+    ):
+        store = NioDataStore(
+            filename_or_obj,
+            mode=mode,
+            lock=lock,
         )
-    return ds
 
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds
 
-pynio_backend = BackendEntrypoint(open_dataset=open_backend_dataset_pynio)

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -7,7 +7,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     AbstractDataStore,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
 )
 from .file_manager import CachingFileManager
 from .locks import HDF5_LOCK, NETCDFC_LOCK, SerializableLock, combine_locks, ensure_lock
@@ -97,7 +97,7 @@ class NioDataStore(AbstractDataStore):
         self._manager.close()
 
 
-class PynioBackendEntrypoint(AbstractBackendEntrypoint):
+class PynioBackendEntrypoint(BackendEntrypoint):
 
     def open_dataset(
             filename_or_obj,

--- a/xarray/backends/pynio_.py
+++ b/xarray/backends/pynio_.py
@@ -98,18 +98,17 @@ class NioDataStore(AbstractDataStore):
 
 
 class PynioBackendEntrypoint(BackendEntrypoint):
-
     def open_dataset(
-            filename_or_obj,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            mode="r",
-            lock=None,
+        filename_or_obj,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        mode="r",
+        lock=None,
     ):
         store = NioDataStore(
             filename_or_obj,

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -232,9 +232,7 @@ class ScipyDataStore(WritableCFDataStore):
         self._manager.close()
 
 
-
 class ScipyBackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         try:
             return read_magic_number(store_spec).startswith(b"CDF")
@@ -248,20 +246,20 @@ class ScipyBackendEntrypoint(BackendEntrypoint):
         return ext in {".nc", ".nc4", ".cdf", ".gz"}
 
     def open_dataset(
-            self,
-            filename_or_obj,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            mode="r",
-            format=None,
-            group=None,
-            mmap=None,
-            lock=None,
+        self,
+        filename_or_obj,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        mode="r",
+        format=None,
+        group=None,
+        mmap=None,
+        lock=None,
     ):
 
         store = ScipyDataStore(

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -9,7 +9,7 @@ from ..core.variable import Variable
 from .common import (
     BACKEND_ENTRYPOINTS,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
     WritableCFDataStore,
 )
 from .file_manager import CachingFileManager, DummyFileManager
@@ -233,7 +233,7 @@ class ScipyDataStore(WritableCFDataStore):
 
 
 
-class ScipyBackendEntrypoint(AbstractBackendEntrypoint):
+class ScipyBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         try:

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -6,7 +6,7 @@ import numpy as np
 from ..core.indexing import NumpyIndexingAdapter
 from ..core.utils import Frozen, FrozenDict, close_on_error, read_magic_number
 from ..core.variable import Variable
-from .common import BackendArray, BackendEntrypoint, WritableCFDataStore
+from .common import BackendArray, AbstractBackendEntrypoint, WritableCFDataStore
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import ensure_lock, get_write_lock
 from .netcdf3 import encode_nc3_attr_value, encode_nc3_variable, is_valid_nc3_name
@@ -222,52 +222,51 @@ class ScipyDataStore(WritableCFDataStore):
         self._manager.close()
 
 
-def guess_can_open_scipy(store_spec):
-    try:
-        return read_magic_number(store_spec).startswith(b"CDF")
-    except TypeError:
-        pass
 
-    try:
-        _, ext = os.path.splitext(store_spec)
-    except TypeError:
-        return False
-    return ext in {".nc", ".nc4", ".cdf", ".gz"}
+class ScipyBackendEntrypoint(AbstractBackendEntrypoint):
 
+    def guess_can_open_scipy(self, store_spec):
+        try:
+            return read_magic_number(store_spec).startswith(b"CDF")
+        except TypeError:
+            pass
 
-def open_backend_dataset_scipy(
-    filename_or_obj,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    mode="r",
-    format=None,
-    group=None,
-    mmap=None,
-    lock=None,
-):
+        try:
+            _, ext = os.path.splitext(store_spec)
+        except TypeError:
+            return False
+        return ext in {".nc", ".nc4", ".cdf", ".gz"}
 
-    store = ScipyDataStore(
-        filename_or_obj, mode=mode, format=format, group=group, mmap=mmap, lock=lock
-    )
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+    def open_backend_dataset_scipy(
+            self,
+            filename_or_obj,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            mode="r",
+            format=None,
+            group=None,
+            mmap=None,
+            lock=None,
+    ):
+
+        store = ScipyDataStore(
+            filename_or_obj, mode=mode, format=format, group=group, mmap=mmap, lock=lock
         )
-    return ds
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds
 
-
-scipy_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_scipy, guess_can_open=guess_can_open_scipy
-)

--- a/xarray/backends/scipy_.py
+++ b/xarray/backends/scipy_.py
@@ -10,7 +10,7 @@ from .common import BackendArray, AbstractBackendEntrypoint, WritableCFDataStore
 from .file_manager import CachingFileManager, DummyFileManager
 from .locks import ensure_lock, get_write_lock
 from .netcdf3 import encode_nc3_attr_value, encode_nc3_variable, is_valid_nc3_name
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 
 def _decode_string(s):
@@ -225,7 +225,7 @@ class ScipyDataStore(WritableCFDataStore):
 
 class ScipyBackendEntrypoint(AbstractBackendEntrypoint):
 
-    def guess_can_open_scipy(self, store_spec):
+    def guess_can_open(self, store_spec):
         try:
             return read_magic_number(store_spec).startswith(b"CDF")
         except TypeError:
@@ -237,7 +237,7 @@ class ScipyBackendEntrypoint(AbstractBackendEntrypoint):
             return False
         return ext in {".nc", ".nc4", ".cdf", ".gz"}
 
-    def open_backend_dataset_scipy(
+    def open_dataset(
             self,
             filename_or_obj,
             mask_and_scale=True,
@@ -257,8 +257,10 @@ class ScipyBackendEntrypoint(AbstractBackendEntrypoint):
         store = ScipyDataStore(
             filename_or_obj, mode=mode, format=format, group=group, mmap=mmap, lock=lock
         )
+
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -4,7 +4,6 @@ from .common import BACKEND_ENTRYPOINTS, AbstractDataStore, BackendEntrypoint
 
 
 class StoreBackendEntrypoint(BackendEntrypoint):
-
     def guess_can_open(self, store_spec):
         return isinstance(store_spec, AbstractDataStore)
 

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -1,47 +1,44 @@
 from .. import conventions
 from ..core.dataset import Dataset
-from .common import AbstractDataStore, BackendEntrypoint
+from .common import AbstractBackendEntrypoint, AbstractDataStore
 
 
-def guess_can_open_store(store_spec):
-    return isinstance(store_spec, AbstractDataStore)
+class StoreBackendEntrypoint(AbstractBackendEntrypoint):
 
+    def guess_can_open(self, store_spec):
+        return isinstance(store_spec, AbstractDataStore)
 
-def open_backend_dataset_store(
-    store,
-    *,
-    mask_and_scale=True,
-    decode_times=True,
-    concat_characters=True,
-    decode_coords=True,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-):
-    vars, attrs = store.load()
-    file_obj = store
-    encoding = store.get_encoding()
+    def open_dataset(
+        self,
+        store,
+        *,
+        mask_and_scale=True,
+        decode_times=True,
+        concat_characters=True,
+        decode_coords=True,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+    ):
+        vars, attrs = store.load()
+        file_obj = store
+        encoding = store.get_encoding()
 
-    vars, attrs, coord_names = conventions.decode_cf_variables(
-        vars,
-        attrs,
-        mask_and_scale=mask_and_scale,
-        decode_times=decode_times,
-        concat_characters=concat_characters,
-        decode_coords=decode_coords,
-        drop_variables=drop_variables,
-        use_cftime=use_cftime,
-        decode_timedelta=decode_timedelta,
-    )
+        vars, attrs, coord_names = conventions.decode_cf_variables(
+            vars,
+            attrs,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
 
-    ds = Dataset(vars, attrs=attrs)
-    ds = ds.set_coords(coord_names.intersection(vars))
-    ds._file_obj = file_obj
-    ds.encoding = encoding
+        ds = Dataset(vars, attrs=attrs)
+        ds = ds.set_coords(coord_names.intersection(vars))
+        ds._file_obj = file_obj
+        ds.encoding = encoding
 
-    return ds
-
-
-store_backend = BackendEntrypoint(
-    open_dataset=open_backend_dataset_store, guess_can_open=guess_can_open_store
-)
+        return ds

--- a/xarray/backends/store.py
+++ b/xarray/backends/store.py
@@ -1,9 +1,9 @@
 from .. import conventions
 from ..core.dataset import Dataset
-from .common import BACKEND_ENTRYPOINTS, AbstractDataStore, AbstractBackendEntrypoint
+from .common import BACKEND_ENTRYPOINTS, AbstractDataStore, BackendEntrypoint
 
 
-class StoreBackendEntrypoint(AbstractBackendEntrypoint):
+class StoreBackendEntrypoint(BackendEntrypoint):
 
     def guess_can_open(self, store_spec):
         return isinstance(store_spec, AbstractDataStore)

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -671,24 +671,22 @@ def open_zarr(
 
 
 class ZarrBackendEntrypoint(BackendEntrypoint):
-
-
     def open_dataset(
-            self,
-            filename_or_obj,
-            mask_and_scale=True,
-            decode_times=None,
-            concat_characters=None,
-            decode_coords=None,
-            drop_variables=None,
-            use_cftime=None,
-            decode_timedelta=None,
-            group=None,
-            mode="r",
-            synchronizer=None,
-            consolidated=False,
-            consolidate_on_close=False,
-            chunk_store=None,
+        self,
+        filename_or_obj,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        group=None,
+        mode="r",
+        synchronizer=None,
+        consolidated=False,
+        consolidate_on_close=False,
+        chunk_store=None,
     ):
         store = ZarrStore.open_group(
             filename_or_obj,

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -11,7 +11,7 @@ from ..core.variable import Variable
 from .common import (
     AbstractWritableDataStore,
     BackendArray,
-    BackendEntrypoint,
+    AbstractBackendEntrypoint,
     _encode_variable_name,
 )
 from .store import open_backend_dataset_store
@@ -663,45 +663,45 @@ def open_zarr(
     return ds
 
 
-def open_backend_dataset_zarr(
-    filename_or_obj,
-    mask_and_scale=True,
-    decode_times=None,
-    concat_characters=None,
-    decode_coords=None,
-    drop_variables=None,
-    use_cftime=None,
-    decode_timedelta=None,
-    group=None,
-    mode="r",
-    synchronizer=None,
-    consolidated=False,
-    consolidate_on_close=False,
-    chunk_store=None,
-):
+class ZarrBackendEntrypoint(AbstractBackendEntrypoint):
 
-    store = ZarrStore.open_group(
-        filename_or_obj,
-        group=group,
-        mode=mode,
-        synchronizer=synchronizer,
-        consolidated=consolidated,
-        consolidate_on_close=consolidate_on_close,
-        chunk_store=chunk_store,
-    )
 
-    with close_on_error(store):
-        ds = open_backend_dataset_store(
-            store,
-            mask_and_scale=mask_and_scale,
-            decode_times=decode_times,
-            concat_characters=concat_characters,
-            decode_coords=decode_coords,
-            drop_variables=drop_variables,
-            use_cftime=use_cftime,
-            decode_timedelta=decode_timedelta,
+    def open_backend_dataset_zarr(
+            self,
+            filename_or_obj,
+            mask_and_scale=True,
+            decode_times=None,
+            concat_characters=None,
+            decode_coords=None,
+            drop_variables=None,
+            use_cftime=None,
+            decode_timedelta=None,
+            group=None,
+            mode="r",
+            synchronizer=None,
+            consolidated=False,
+            consolidate_on_close=False,
+            chunk_store=None,
+    ):
+        store = ZarrStore.open_group(
+            filename_or_obj,
+            group=group,
+            mode=mode,
+            synchronizer=synchronizer,
+            consolidated=consolidated,
+            consolidate_on_close=consolidate_on_close,
+            chunk_store=chunk_store,
         )
-    return ds
 
-
-zarr_backend = BackendEntrypoint(open_dataset=open_backend_dataset_zarr)
+        with close_on_error(store):
+            ds = open_backend_dataset_store(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -12,7 +12,7 @@ from .common import (
     BACKEND_ENTRYPOINTS,
     AbstractWritableDataStore,
     BackendArray,
-    AbstractBackendEntrypoint,
+    BackendEntrypoint,
     _encode_variable_name,
 )
 from .store import StoreBackendEntrypoint
@@ -670,7 +670,7 @@ def open_zarr(
     return ds
 
 
-class ZarrBackendEntrypoint(AbstractBackendEntrypoint):
+class ZarrBackendEntrypoint(BackendEntrypoint):
 
 
     def open_dataset(

--- a/xarray/backends/zarr.py
+++ b/xarray/backends/zarr.py
@@ -14,7 +14,7 @@ from .common import (
     AbstractBackendEntrypoint,
     _encode_variable_name,
 )
-from .store import open_backend_dataset_store
+from .store import StoreBackendEntrypoint
 
 # need some special secret attributes to tell us the dimensions
 DIMENSION_KEY = "_ARRAY_DIMENSIONS"
@@ -666,7 +666,7 @@ def open_zarr(
 class ZarrBackendEntrypoint(AbstractBackendEntrypoint):
 
 
-    def open_backend_dataset_zarr(
+    def open_dataset(
             self,
             filename_or_obj,
             mask_and_scale=True,
@@ -693,8 +693,9 @@ class ZarrBackendEntrypoint(AbstractBackendEntrypoint):
             chunk_store=chunk_store,
         )
 
+        store_entrypoint = StoreBackendEntrypoint()
         with close_on_error(store):
-            ds = open_backend_dataset_store(
+            ds = store_entrypoint.open_dataset(
                 store,
                 mask_and_scale=mask_and_scale,
                 decode_times=decode_times,

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -6,7 +6,6 @@ import pytest
 from xarray.backends import common, plugins
 
 
-
 class DummyBackendEntrypointArgs(common.BackendEntrypoint):
     def open_dataset(filename_or_obj, *args):
         pass
@@ -18,12 +17,12 @@ class DummyBackendEntrypointKwargs(common.BackendEntrypoint):
 
 
 class DummyBackendEntrypoint1(common.BackendEntrypoint):
-    def open_dataset(self, filename_or_obj, *, decoder ):
+    def open_dataset(self, filename_or_obj, *, decoder):
         pass
 
 
 class DummyBackendEntrypoint2(common.BackendEntrypoint):
-    def open_dataset(self, filename_or_obj, *, decoder ):
+    def open_dataset(self, filename_or_obj, *, decoder):
         pass
 
 
@@ -103,9 +102,10 @@ def test_set_missing_parameters_raise_error():
         plugins.set_missing_parameters({"engine": backend})
 
 
-
-
-@mock.patch("pkg_resources.EntryPoint.load", mock.MagicMock(return_value=DummyBackendEntrypoint1))
+@mock.patch(
+    "pkg_resources.EntryPoint.load",
+    mock.MagicMock(return_value=DummyBackendEntrypoint1),
+)
 def test_build_engines():
     dummy_pkg_entrypoint = pkg_resources.EntryPoint.parse(
         "cfgrib = xarray.tests.test_plugins:backend_1"

--- a/xarray/tests/test_plugins.py
+++ b/xarray/tests/test_plugins.py
@@ -6,19 +6,25 @@ import pytest
 from xarray.backends import common, plugins
 
 
-def dummy_open_dataset_args(filename_or_obj, *args):
-    pass
+
+class DummyBackendEntrypointArgs(common.BackendEntrypoint):
+    def open_dataset(filename_or_obj, *args):
+        pass
 
 
-def dummy_open_dataset_kwargs(filename_or_obj, **kwargs):
-    pass
+class DummyBackendEntrypointKwargs(common.BackendEntrypoint):
+    def open_dataset(filename_or_obj, **kwargs):
+        pass
 
 
-def dummy_open_dataset(filename_or_obj, *, decoder):
-    pass
+class DummyBackendEntrypoint1(common.BackendEntrypoint):
+    def open_dataset(self, filename_or_obj, *, decoder ):
+        pass
 
 
-dummy_cfgrib = common.BackendEntrypoint(dummy_open_dataset)
+class DummyBackendEntrypoint2(common.BackendEntrypoint):
+    def open_dataset(self, filename_or_obj, *, decoder ):
+        pass
 
 
 @pytest.fixture
@@ -65,46 +71,47 @@ def test_create_engines_dict():
 
 
 def test_set_missing_parameters():
-    backend_1 = common.BackendEntrypoint(dummy_open_dataset)
-    backend_2 = common.BackendEntrypoint(dummy_open_dataset, ("filename_or_obj",))
+    backend_1 = DummyBackendEntrypoint1
+    backend_2 = DummyBackendEntrypoint2
+    backend_2.open_dataset_parameters = ("filename_or_obj",)
     engines = {"engine_1": backend_1, "engine_2": backend_2}
     plugins.set_missing_parameters(engines)
 
     assert len(engines) == 2
-    engine_1 = engines["engine_1"]
-    assert engine_1.open_dataset_parameters == ("filename_or_obj", "decoder")
-    engine_2 = engines["engine_2"]
-    assert engine_2.open_dataset_parameters == ("filename_or_obj",)
+    assert backend_1.open_dataset_parameters == ("filename_or_obj", "decoder")
+    assert backend_2.open_dataset_parameters == ("filename_or_obj",)
+
+    backend = DummyBackendEntrypointKwargs()
+    backend.open_dataset_parameters = ("filename_or_obj", "decoder")
+    plugins.set_missing_parameters({"engine": backend})
+    assert backend.open_dataset_parameters == ("filename_or_obj", "decoder")
+
+    backend = DummyBackendEntrypointArgs()
+    backend.open_dataset_parameters = ("filename_or_obj", "decoder")
+    plugins.set_missing_parameters({"engine": backend})
+    assert backend.open_dataset_parameters == ("filename_or_obj", "decoder")
 
 
 def test_set_missing_parameters_raise_error():
 
-    backend = common.BackendEntrypoint(dummy_open_dataset_args)
+    backend = DummyBackendEntrypointKwargs()
     with pytest.raises(TypeError):
         plugins.set_missing_parameters({"engine": backend})
 
-    backend = common.BackendEntrypoint(
-        dummy_open_dataset_args, ("filename_or_obj", "decoder")
-    )
-    plugins.set_missing_parameters({"engine": backend})
-
-    backend = common.BackendEntrypoint(dummy_open_dataset_kwargs)
+    backend = DummyBackendEntrypointArgs()
     with pytest.raises(TypeError):
         plugins.set_missing_parameters({"engine": backend})
 
-    backend = common.BackendEntrypoint(
-        dummy_open_dataset_kwargs, ("filename_or_obj", "decoder")
-    )
-    plugins.set_missing_parameters({"engine": backend})
 
 
-@mock.patch("pkg_resources.EntryPoint.load", mock.MagicMock(return_value=dummy_cfgrib))
+
+@mock.patch("pkg_resources.EntryPoint.load", mock.MagicMock(return_value=DummyBackendEntrypoint1))
 def test_build_engines():
-    dummy_cfgrib_pkg_entrypoint = pkg_resources.EntryPoint.parse(
+    dummy_pkg_entrypoint = pkg_resources.EntryPoint.parse(
         "cfgrib = xarray.tests.test_plugins:backend_1"
     )
-    backend_entrypoints = plugins.build_engines([dummy_cfgrib_pkg_entrypoint])
-    assert backend_entrypoints["cfgrib"] is dummy_cfgrib
+    backend_entrypoints = plugins.build_engines([dummy_pkg_entrypoint])
+    assert isinstance(backend_entrypoints["cfgrib"], DummyBackendEntrypoint1)
     assert backend_entrypoints["cfgrib"].open_dataset_parameters == (
         "filename_or_obj",
         "decoder",


### PR DESCRIPTION
Currently, the interface between the backend and xarray is the class/container BackendEntrypoint to be instantiated by the backend.
With this pull request, BackendEntrypoint is replaced by AbstractBackendEntrypoint. The backend will inherit from this class.

Reasons for these changes:
- This interface is more standard
- In AbstractBackendEntrypoint it can be provided with the description of the interface.